### PR TITLE
Improve training calibration UX and guard messaging

### DIFF
--- a/toptek/gui/widgets.py
+++ b/toptek/gui/widgets.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import tkinter as tk
 from tkinter import messagebox, ttk
-from typing import Dict
+from typing import Any, Dict
 
 import numpy as np
 
@@ -22,6 +22,50 @@ class BaseTab(ttk.Frame):
         self.configs = configs
         self.paths = paths
         self.logger = utils.build_logger(self.__class__.__name__)
+        self._status_palette = {
+            "info": "#1d4ed8",
+            "success": "#15803d",
+            "warning": "#b45309",
+            "error": "#b91c1c",
+            "neutral": "",
+        }
+
+    def log_event(self, message: str, *, level: str = "info", exc: Exception | None = None) -> None:
+        """Log an event using the tab's logger.
+
+        Args:
+            message: Event description.
+            level: Logging level name to dispatch (defaults to ``info``).
+        """
+
+        normalized = level.lower()
+        if normalized == "warn":
+            normalized = "warning"
+        log_method = getattr(self.logger, normalized, self.logger.info)
+        if exc is not None:
+            log_method(message, exc_info=exc)
+        else:
+            log_method(message)
+
+    def update_section(self, section: str, updates: Dict[str, object]) -> None:
+        """Update the configuration state for *section* with *updates*."""
+
+        section_state = self.configs.setdefault(section, {})
+        self._deep_update(section_state, updates)
+
+    def set_status(self, label: ttk.Label, text: str, *, tone: str = "info") -> None:
+        """Apply consistent text/colour styling to status labels."""
+
+        palette_key = tone.lower()
+        foreground = self._status_palette.get(palette_key, self._status_palette["info"])
+        label.config(text=text, foreground=foreground)
+
+    def _deep_update(self, target: Dict[str, Any], updates: Dict[str, Any]) -> None:
+        for key, value in updates.items():
+            if isinstance(value, dict) and isinstance(target.get(key), dict):
+                self._deep_update(target[key], value)
+            else:
+                target[key] = value
 
 
 class LoginTab(BaseTab):
@@ -60,8 +104,9 @@ class LoginTab(BaseTab):
         actions.pack(fill=tk.X, padx=10, pady=(0, 12))
         ttk.Button(actions, text="Save .env", command=self._save_env).pack(side=tk.LEFT, padx=(0, 6))
         ttk.Button(actions, text="Verify entries", command=self._verify_env).pack(side=tk.LEFT)
-        self.status = ttk.Label(actions, text="Awaiting verification", foreground="#1d4ed8")
+        self.status = ttk.Label(actions)
         self.status.pack(side=tk.LEFT, padx=12)
+        self.set_status(self.status, "Awaiting verification", tone="info")
 
     def _env_value(self, key: str) -> str:
         return os.environ.get(key, "")
@@ -72,16 +117,16 @@ class LoginTab(BaseTab):
             for key, var in self.vars.items():
                 handle.write(f"{key}={var.get()}\n")
         messagebox.showinfo("Settings", f"Saved credentials to {env_path}")
-        self.status.config(text="Saved. Run verification to confirm access.", foreground="#166534")
+        self.set_status(self.status, "Saved. Run verification to confirm access.", tone="success")
 
     def _verify_env(self) -> None:
         missing = [key for key, var in self.vars.items() if not var.get().strip()]
         if missing:
             details = ", ".join(missing)
-            self.status.config(text=f"Missing: {details}", foreground="#b91c1c")
+            self.set_status(self.status, f"Missing: {details}", tone="error")
             messagebox.showwarning("Verification", f"Provide values for: {details}")
             return
-        self.status.config(text="All keys present. Proceed to Research ▶", foreground="#15803d")
+        self.set_status(self.status, "All keys present. Proceed to Research ▶", tone="success")
         messagebox.showinfo("Verification", "Environment entries look complete. Continue to the next tab.")
 
 
@@ -198,8 +243,10 @@ class TrainTab(BaseTab):
 
         self.output = tk.Text(self, height=12)
         self.output.pack(fill=tk.BOTH, expand=True, padx=10, pady=(6, 4))
-        self.status = ttk.Label(self, text="Awaiting training run", anchor=tk.W)
+        self.status = ttk.Label(self, anchor=tk.W)
         self.status.pack(fill=tk.X, padx=12, pady=(0, 12))
+        self.set_status(self.status, "Awaiting training run", tone="info")
+        self._last_calibration_warning: str | None = None
 
     def _train_model(self) -> None:
         try:
@@ -207,27 +254,71 @@ class TrainTab(BaseTab):
         except (TypeError, ValueError):
             lookback = 480
         lookback = max(240, min(lookback, 2000))
+        self.log_event(
+            f"Training started for {self.model_type.get()} with lookback={lookback}",
+            level="info",
+        )
         df = sample_dataframe(lookback)
         feat_map = features.compute_features(df)
         X = np.column_stack(list(feat_map.values()))
         y = (np.diff(df["close"], prepend=df["close"].iloc[0]) > 0).astype(int)
         result = model.train_classifier(X, y, model_type=self.model_type.get(), models_dir=self.paths.models)
         calibrate_report = "skipped"
+        calibration_failed = False
         if self.calibrate_var.get() and len(X) > 60:
             cal_size = max(60, int(len(X) * 0.2))
             X_cal = X[-cal_size:]
             y_cal = y[-cal_size:]
-            calibrated_path = model.calibrate_classifier(result.model_path, (X_cal, y_cal))
-            calibrate_report = f"calibrated → {calibrated_path.name}"
+            try:
+                calibrated_path = model.calibrate_classifier(result.model_path, (X_cal, y_cal))
+            except (ValueError, RuntimeError) as exc:
+                calibrate_report = f"skipped calibration · {type(exc).__name__}: {exc}".strip()
+                calibration_failed = True
+                self.log_event(
+                    f"Calibration failed for {result.model_path.name}: {type(exc).__name__}: {exc}",
+                    level="warning",
+                    exc=exc,
+                )
+                self.set_status(
+                    self.status,
+                    "Calibration skipped due to data quality. Review logs for details.",
+                    tone="error",
+                )
+                warning_body = (
+                    "Probability calibration failed with the current sample. "
+                    "The base model artefact is saved without calibration.\n\n"
+                    f"Details: {type(exc).__name__}: {exc}"
+                )
+                if warning_body != self._last_calibration_warning:
+                    messagebox.showwarning("Calibration warning", warning_body)
+                    self._last_calibration_warning = warning_body
+            else:
+                calibrate_report = f"calibrated → {calibrated_path.name}"
+                self._last_calibration_warning = None
+                self.log_event(
+                    f"Calibration completed for {result.model_path.name} → {calibrated_path.name}",
+                    level="info",
+                )
         self.output.delete("1.0", tk.END)
         payload = {
             "model": self.model_type.get(),
             "metrics": result.metrics,
             "threshold": result.threshold,
             "calibration": calibrate_report,
+            "calibration_status": "skipped" if calibration_failed else "success",
         }
         self.output.insert(tk.END, json_dumps(payload))
-        self.status.config(text="Model artefact refreshed. Continue to Backtest ▶")
+        self.update_section("training", payload)
+        if not calibration_failed:
+            self.set_status(
+                self.status,
+                "Model artefact refreshed. Continue to Backtest ▶",
+                tone="success",
+            )
+        self.log_event(
+            f"Training completed for {result.model_path.name} (calibration={payload['calibration_status']})",
+            level="info",
+        )
 
 
 class BacktestTab(BaseTab):
@@ -271,8 +362,9 @@ class BacktestTab(BaseTab):
 
         self.output = tk.Text(self, height=14)
         self.output.pack(fill=tk.BOTH, expand=True, padx=10, pady=(6, 4))
-        self.status = ttk.Label(self, text="No simulations yet", anchor=tk.W)
+        self.status = ttk.Label(self, anchor=tk.W)
         self.status.pack(fill=tk.X, padx=12, pady=(0, 12))
+        self.set_status(self.status, "No simulations yet", tone="info")
 
     def _run_backtest(self) -> None:
         try:
@@ -298,7 +390,11 @@ class BacktestTab(BaseTab):
         }
         self.output.delete("1.0", tk.END)
         self.output.insert(tk.END, json_dumps(payload))
-        self.status.config(text="Sim complete. If expectancy holds, draft a manual trade plan ▶")
+        self.set_status(
+            self.status,
+            "Sim complete. If expectancy holds, draft a manual trade plan ▶",
+            tone="success",
+        )
 
 
 class TradeTab(BaseTab):
@@ -357,6 +453,12 @@ class TradeTab(BaseTab):
         }
         self.output.delete("1.0", tk.END)
         self.output.insert(tk.END, json_dumps(payload))
+        guard_message = (
+            "Guard status OK — within limits. Proceed only with fully vetted manual plans."
+            if guard == "OK"
+            else "Topstep guard engaged DEFENSIVE_MODE. Stand down and review journal before trading."
+        )
+        messagebox.showinfo("Topstep guard", guard_message)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- add shared status styling, level-normalized logging, and deep-merge config updates in `BaseTab`
- harden training flow logging, debounce calibration warnings, and persist calibration status metadata
- surface Topstep guard refresh results with informational dialogs for both OK and defensive outcomes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e06102539883298d759c449682321d