### PR TITLE
Fix original feature count tracking in classifier training

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,23 @@
+"""Tests for the training helpers in :mod:`toptek.core.model`."""
+
+from pathlib import Path
+
+import numpy as np
+
+from toptek.core.model import train_classifier
+
+
+def test_train_classifier_records_original_feature_count(tmp_path: Path) -> None:
+    """Training should succeed even when all-NaN columns are removed."""
+
+    rng = np.random.default_rng(42)
+    X = rng.normal(size=(60, 5))
+    X[:, 2] = np.nan  # Simulate a column that will be dropped entirely
+    X[0, :] = np.nan  # Ensure at least one row gets dropped
+    y = (X[:, 0] > X[:, 1]).astype(int)
+
+    result = train_classifier(X, y, models_dir=tmp_path)
+
+    assert result.original_feature_count == 5
+    assert result.retained_columns == (0, 1, 3, 4)
+    assert result.model_path.exists()

--- a/toptek/core/model.py
+++ b/toptek/core/model.py
@@ -81,6 +81,7 @@ def train_classifier(
 
     if X.ndim != 2:
         raise ValueError("Feature matrix must be 2-dimensional")
+    original_feature_count = X.shape[1]
     y = np.asarray(y).ravel()
 
     if not np.isfinite(X).all() or not np.isfinite(y).all():


### PR DESCRIPTION
## Summary
- capture the original feature count before matrix cleaning in `train_classifier`
- propagate that value into the returned `TrainResult`
- add a regression test to ensure training succeeds when dropping all-NaN columns

## Testing
- `pytest` *(fails: missing numpy dependency in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e08344cfdc8329b46ce49f9b968afa