### PR TITLE
Pin scientific stack versions for scikit-learn 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # porjectx
+
+## Dependency compatibility
+
+The `toptek/requirements-lite.txt` file pins the scientific stack to keep it
+compatible with the bundled scikit-learn release:
+
+- `scikit-learn==1.3.2`
+- `numpy>=1.21.6,<2.0`
+- `scipy>=1.7.3,<1.12`
+
+These ranges follow the support window published by scikit-learn 1.3.x and are
+also consumed transitively by `toptek/requirements-streaming.txt` through its
+`-r requirements-lite.txt` include. Installing within these bounds avoids the
+ABI mismatches that occur with the NumPy/SciPy wheels when using newer major
+releases.
+
+## Verifying the environment
+
+Create and activate a Python 3.10+ virtual environment, then install and check
+for compatibility issues:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r toptek/requirements-lite.txt
+pip check
+```
+
+The final `pip check` call should report "No broken requirements found",
+confirming that the pinned dependency set resolves without conflicts.

--- a/toptek/requirements-lite.txt
+++ b/toptek/requirements-lite.txt
@@ -1,7 +1,8 @@
 httpx
 python-dotenv
 pyyaml
-numpy
+numpy>=1.21.6,<2.0
+scipy>=1.7.3,<1.12
 ta
-scikit-learn
+scikit-learn==1.3.2
 pandas


### PR DESCRIPTION
## Summary
- pin numpy and scipy ranges compatible with scikit-learn 1.3.2 in the lite requirements set
- document the new dependency bounds and verification steps in the README

## Testing
- pip install -r toptek/requirements-lite.txt *(fails: proxy blocks package downloads)*
- pip check

------
https://chatgpt.com/codex/tasks/task_e_68e085a94388832982a9615d83bb3658