### PR TITLE
Document NumPy compatibility ceiling

### DIFF
--- a/toptek/README.md
+++ b/toptek/README.md
@@ -62,7 +62,7 @@ Configuration defaults live under the `config/` folder and are merged with value
 
 ## Requirements profiles
 
-- `requirements-lite.txt`: minimal dependencies for polling workflows.
+- `requirements-lite.txt`: minimal dependencies for polling workflows. NumPy is capped below 1.28 so the bundled SciPy wheels stay importable; installing NumPy 2.x triggers a SciPy `ImportError` about missing manylinux-compatible binaries.
 - `requirements-streaming.txt`: extends the lite profile with optional SignalR streaming support.
 
 ## Development notes

--- a/toptek/requirements-lite.txt
+++ b/toptek/requirements-lite.txt
@@ -1,7 +1,7 @@
 httpx
 python-dotenv
 pyyaml
-numpy>=1.21.6,<2.0
+numpy>=1.21.6,<1.28
 scipy>=1.7.3,<1.12
 ta
 scikit-learn==1.3.2


### PR DESCRIPTION
## Summary
- cap NumPy below 1.28 in the lite dependency profile to align with the bundled SciPy wheels
- document the NumPy ceiling in the requirements section so users understand the SciPy import error they will see above the cap

## Testing
- `pip install -r toptek/requirements-lite.txt` *(fails in CI environment: proxy 403 while downloading packages)*
- `pip check`


------
https://chatgpt.com/codex/tasks/task_e_68e08b4f47d48329827e1ed6abe8357b