### PR TITLE
Implement dark theme styling for Toptek GUI

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+explicit_package_bases = True
+ignore_missing_imports = True
+files = toptek/gui

--- a/toptek/core/backtest.py
+++ b/toptek/core/backtest.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict
 
 import numpy as np
 
@@ -19,19 +18,29 @@ class BacktestResult:
     equity_curve: np.ndarray
 
 
-def run_backtest(returns: np.ndarray, signals: np.ndarray, *, fee_per_trade: float = 0.0) -> BacktestResult:
+def run_backtest(
+    returns: np.ndarray, signals: np.ndarray, *, fee_per_trade: float = 0.0
+) -> BacktestResult:
     """Run a simple long/flat backtest."""
 
     trade_returns = returns * signals - fee_per_trade
     equity_curve = np.cumsum(trade_returns)
     wins = trade_returns > 0
     hit_rate = float(wins.mean()) if len(trade_returns) else 0.0
-    sharpe = float(np.mean(trade_returns) / (np.std(trade_returns) + 1e-9) * np.sqrt(252))
+    sharpe = float(
+        np.mean(trade_returns) / (np.std(trade_returns) + 1e-9) * np.sqrt(252)
+    )
     running_max = np.maximum.accumulate(equity_curve)
     drawdowns = running_max - equity_curve
     max_drawdown = float(drawdowns.max()) if len(drawdowns) else 0.0
     expectancy = float(np.mean(trade_returns))
-    return BacktestResult(hit_rate=hit_rate, sharpe=sharpe, max_drawdown=max_drawdown, expectancy=expectancy, equity_curve=equity_curve)
+    return BacktestResult(
+        hit_rate=hit_rate,
+        sharpe=sharpe,
+        max_drawdown=max_drawdown,
+        expectancy=expectancy,
+        equity_curve=equity_curve,
+    )
 
 
 __all__ = ["run_backtest", "BacktestResult"]

--- a/toptek/core/live.py
+++ b/toptek/core/live.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Dict, Optional
+from typing import Dict
 
 from .gateway import ProjectXGateway
 
@@ -31,15 +31,21 @@ def poll_positions(context: ExecutionContext) -> Dict[str, object]:
 def connect_market_hub(*_, **__) -> None:  # pragma: no cover - stub
     """Placeholder for SignalR market hub connection."""
 
-    raise NotImplementedError("SignalR streaming is optional; install signalrcore to enable")
+    raise NotImplementedError(
+        "SignalR streaming is optional; install signalrcore to enable"
+    )
 
 
 def subscribe_ticker(*_, **__) -> None:  # pragma: no cover - stub
-    raise NotImplementedError("SignalR streaming is optional; install signalrcore to enable")
+    raise NotImplementedError(
+        "SignalR streaming is optional; install signalrcore to enable"
+    )
 
 
 def subscribe_bars(*_, **__) -> None:  # pragma: no cover - stub
-    raise NotImplementedError("SignalR streaming is optional; install signalrcore to enable")
+    raise NotImplementedError(
+        "SignalR streaming is optional; install signalrcore to enable"
+    )
 
 
 __all__ = [

--- a/toptek/gui/README.md
+++ b/toptek/gui/README.md
@@ -1,0 +1,82 @@
+# Toptek GUI Theme
+
+The desktop mission control now ships with a dark dashboard theme that is driven by
+semantic colour tokens. The palette is shared by `toptek/gui/app.py` (style
+registration) and `toptek/gui/widgets.py` (widget construction) through the
+constants exposed in `toptek/gui/__init__.py`.
+
+## Palette tokens
+
+| Token | Hex | Usage |
+| --- | --- | --- |
+| `canvas` | `#0b1120` | Application background, notebook, and root windows. |
+| `surface` | `#111827` | Raised panels such as section frames and dashboard cards. |
+| `surface_alt` | `#1e293b` | Text fields, multi-line editors, and hover states. |
+| `surface_muted` | `#18243a` | Notebook tab hover colour and pressed neutral buttons. |
+| `border` | `#1f2937` | Card borders and section outlines. |
+| `border_muted` | `#243047` | Chart container outlines and disabled controls. |
+| `accent` | `#8b5cf6` | Primary call-to-action buttons and metric values. |
+| `accent_hover` | `#a855f7` | Hover colour for accent buttons. |
+| `accent_active` | `#7c3aed` | Pressed colour for accent buttons. |
+| `accent_alt` | `#38bdf8` | Informational highlights (status text, progress fills). |
+| `text` | `#e2e8f0` | Primary body text. |
+| `text_muted` | `#94a3b8` | Subdued captions and helper copy. |
+| `success` | `#22c55e` | Positive status indicators (verification, guard OK). |
+| `warning` | `#f97316` | Heads-up alerts that require follow-up action. |
+| `danger` | `#f87171` | Blocking errors or defensive guard states. |
+
+## Tk styles
+
+`launch_app` registers the reusable ttk styles that every tab consumes:
+
+- **Layout styles** – `DashboardBackground.TFrame`, `AppContainer.TFrame`,
+  `Section.TLabelframe`, `DashboardCard.TFrame`, and `ChartContainer.TFrame`
+  align structural backgrounds and borders across the notebook.
+- **Typography styles** – `Header.TLabel`, `SubHeader.TLabel`, `Body.TLabel`,
+  `Surface.TLabel`, `CardHeading.TLabel`, `MetricValue.TLabel`, and
+  `MetricCaption.TLabel` keep copy aligned with the light-on-dark palette.
+- **Status styles** – `StatusInfo.TLabel` (for canvas backgrounds) and
+  `SurfaceStatus.TLabel` (for raised surfaces) hold highlights such as
+  verification outcomes and guard readiness.
+- **Input styles** – `Input.TEntry`, `Input.TCombobox`, `Input.TSpinbox`,
+  `Input.TRadiobutton`, and `Input.TCheckbutton` provide consistent field
+  surfaces while default buttons consume either `Accent.TButton` (primary
+  actions) or `Neutral.TButton` (secondary actions).
+- **Feedback styles** – `Accent.Horizontal.TProgressbar` colours the mission
+  checklist progress bar and the notebook tabs receive hover/active maps for
+  modern feedback.
+
+`BaseTab.style_text_widget` applies the `TEXT_WIDGET_DEFAULTS` tokens to every
+`tk.Text` instance so scrollable panes match the rest of the experience.
+
+## Usage guidelines
+
+1. **Choose the right surface** – Wrap new tab sections in
+   `Section.TLabelframe` when you need a contained card; use
+   `DashboardBackground.TFrame` for neutral layouts.
+2. **Buttons** – Reserve `Accent.TButton` for primary calls-to-action and
+   fall back to `Neutral.TButton` for supportive controls. Both have hover and
+   pressed colour maps baked in.
+3. **Text entries** – Always request the `Input.*` styles on ttk entry,
+   combobox, spinbox, radio, or checkbutton widgets so field backgrounds stay
+   coordinated with the palette.
+4. **Statuses** – Prefer the status styles rather than setting literal colours.
+   For context-specific overrides (e.g., success/danger), reuse the
+   `DARK_PALETTE` tokens from `toptek/gui/__init__.py`.
+5. **Dashboard extensions** – New cards in `DashboardTab` should follow the
+   existing pattern: `DashboardCard.TFrame` containers with a heading label,
+   `MetricValue.TLabel` for the primary figure, and `MetricCaption.TLabel` for
+   the descriptive copy. Charts and rich panes should sit inside
+   `ChartContainer.TFrame` to inherit border and padding rules.
+
+## Extending the theme
+
+- Extend `DARK_PALETTE` when introducing additional semantic colours and update
+  both this table and any affected ttk styles.
+- Keep ttk style registration centralised in `launch_app` so the theme remains
+  declarative and easy to audit.
+- When adding new text widgets, call `BaseTab.style_text_widget` immediately
+  after instantiation to apply the shared configuration.
+- Run the linter/test suite (`ruff`, `black`, `mypy`, `pytest`) after theme
+  changes to guard against regressions—the project CI expects these gates.
+

--- a/toptek/gui/__init__.py
+++ b/toptek/gui/__init__.py
@@ -1,1 +1,35 @@
 """GUI modules for Toptek."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+DARK_PALETTE: Dict[str, str] = {
+    "canvas": "#0b1120",
+    "surface": "#111827",
+    "surface_alt": "#1e293b",
+    "surface_muted": "#18243a",
+    "border": "#1f2937",
+    "border_muted": "#243047",
+    "accent": "#8b5cf6",
+    "accent_hover": "#a855f7",
+    "accent_active": "#7c3aed",
+    "accent_alt": "#38bdf8",
+    "text": "#e2e8f0",
+    "text_muted": "#94a3b8",
+    "success": "#22c55e",
+    "warning": "#f97316",
+    "danger": "#f87171",
+}
+
+TEXT_WIDGET_DEFAULTS: Dict[str, Any] = {
+    "background": DARK_PALETTE["surface_alt"],
+    "foreground": DARK_PALETTE["text"],
+    "insertbackground": DARK_PALETTE["accent"],
+    "highlightthickness": 0,
+    "bd": 0,
+    "selectbackground": DARK_PALETTE["accent"],
+    "selectforeground": DARK_PALETTE["canvas"],
+}
+
+__all__ = ["DARK_PALETTE", "TEXT_WIDGET_DEFAULTS"]

--- a/toptek/gui/app.py
+++ b/toptek/gui/app.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import tkinter as tk
 from tkinter import ttk
-from typing import Dict, List
+from typing import Callable, Dict, List
 
 from core import utils
+
+from . import DARK_PALETTE
 
 
 class ToptekApp(ttk.Notebook):
@@ -18,14 +20,15 @@ class ToptekApp(ttk.Notebook):
         configs: Dict[str, Dict[str, object]],
         paths: utils.AppPaths,
         *,
-        on_tab_change: callable | None = None,
+        on_tab_change: Callable[[int, str, str], None] | None = None,
     ) -> None:
-        super().__init__(master)
+        super().__init__(master, style="Dashboard.TNotebook")
         self.configs = configs
         self.paths = paths
         self._on_tab_change = on_tab_change
         self._tab_names: List[str] = []
         self._tab_guidance: Dict[str, str] = {}
+        self._tab_widgets: Dict[str, ttk.Frame] = {}
         self._build_tabs()
         self.bind("<<NotebookTabChanged>>", self._handle_tab_change)
 
@@ -33,6 +36,10 @@ class ToptekApp(ttk.Notebook):
         from . import widgets
 
         tabs = {
+            "Dashboard": (
+                widgets.DashboardTab,
+                "Overview · Monitor readiness metrics before taking action.",
+            ),
             "Login": (
                 widgets.LoginTab,
                 "Step 1 · Secure your API keys and verify environment access.",
@@ -59,6 +66,7 @@ class ToptekApp(ttk.Notebook):
             self.add(frame, text=name)
             self._tab_names.append(name)
             self._tab_guidance[name] = guidance
+            self._tab_widgets[name] = frame
 
     def initialise_guidance(self) -> None:
         """Invoke the guidance callback for the default tab."""
@@ -72,9 +80,14 @@ class ToptekApp(ttk.Notebook):
         self._dispatch_tab_change(index)
 
     def _dispatch_tab_change(self, index: int) -> None:
+        name = self._tab_names[index]
+        widget = self._tab_widgets.get(name)
+        if widget is not None:
+            on_activated = getattr(widget, "on_activated", None)
+            if callable(on_activated):
+                on_activated()
         if self._on_tab_change is None:
             return
-        name = self._tab_names[index]
         guidance = self._tab_guidance.get(name, "")
         self._on_tab_change(index, name, guidance)
 
@@ -92,39 +105,323 @@ def launch_app(*, configs: Dict[str, Dict[str, object]], paths: utils.AppPaths) 
     except tk.TclError:
         # ``clam`` is widely available, but gracefully fallback if missing.
         pass
-    style.configure("Header.TLabel", font=("Segoe UI", 20, "bold"))
-    style.configure("SubHeader.TLabel", font=("Segoe UI", 12))
-    style.configure("Step.TLabel", font=("Segoe UI", 11))
-    style.configure("Guidance.TLabelframe", padding=(12, 10))
-    style.configure("Guidance.TLabelframe.Label", font=("Segoe UI", 11, "bold"))
-    style.configure("TNotebook.Tab", padding=(14, 8))
 
-    container = ttk.Frame(root, padding=16)
+    root.configure(background=DARK_PALETTE["canvas"])
+    style.configure(
+        ".",
+        background=DARK_PALETTE["canvas"],
+        foreground=DARK_PALETTE["text"],
+    )
+    style.configure("TFrame", background=DARK_PALETTE["canvas"])
+    style.configure(
+        "TLabel", background=DARK_PALETTE["canvas"], foreground=DARK_PALETTE["text"]
+    )
+    style.configure("TNotebook", background=DARK_PALETTE["canvas"], borderwidth=0)
+    style.configure(
+        "Dashboard.TNotebook",
+        background=DARK_PALETTE["canvas"],
+        borderwidth=0,
+        tabmargins=(0, 12, 0, 0),
+    )
+    style.configure(
+        "TNotebook.Tab",
+        background=DARK_PALETTE["surface"],
+        foreground=DARK_PALETTE["text_muted"],
+        padding=(16, 10),
+    )
+    style.map(
+        "TNotebook.Tab",
+        background=[
+            ("selected", DARK_PALETTE["surface_alt"]),
+            ("active", DARK_PALETTE["surface_muted"]),
+        ],
+        foreground=[
+            ("selected", DARK_PALETTE["text"]),
+            ("active", DARK_PALETTE["text"]),
+        ],
+    )
+    style.configure(
+        "DashboardBackground.TFrame",
+        background=DARK_PALETTE["canvas"],
+    )
+    style.configure(
+        "AppContainer.TFrame",
+        background=DARK_PALETTE["canvas"],
+    )
+    style.configure(
+        "Header.TLabel",
+        background=DARK_PALETTE["canvas"],
+        foreground=DARK_PALETTE["text"],
+        font=("Segoe UI", 20, "bold"),
+    )
+    style.configure(
+        "SubHeader.TLabel",
+        background=DARK_PALETTE["canvas"],
+        foreground=DARK_PALETTE["text_muted"],
+        font=("Segoe UI", 12),
+    )
+    style.configure(
+        "Step.TLabel",
+        background=DARK_PALETTE["surface"],
+        foreground=DARK_PALETTE["accent_alt"],
+        font=("Segoe UI", 11),
+    )
+    style.configure(
+        "Body.TLabel",
+        background=DARK_PALETTE["canvas"],
+        foreground=DARK_PALETTE["text"],
+        font=("Segoe UI", 10),
+    )
+    style.configure(
+        "Surface.TLabel",
+        background=DARK_PALETTE["surface"],
+        foreground=DARK_PALETTE["text"],
+        font=("Segoe UI", 10),
+    )
+    style.configure(
+        "Muted.TLabel",
+        background=DARK_PALETTE["surface"],
+        foreground=DARK_PALETTE["text_muted"],
+        font=("Segoe UI", 10),
+    )
+    style.configure(
+        "StatusInfo.TLabel",
+        background=DARK_PALETTE["canvas"],
+        foreground=DARK_PALETTE["accent_alt"],
+        font=("Segoe UI", 10, "bold"),
+    )
+    style.configure(
+        "SurfaceStatus.TLabel",
+        background=DARK_PALETTE["surface"],
+        foreground=DARK_PALETTE["accent_alt"],
+        font=("Segoe UI", 10, "bold"),
+    )
+    style.configure(
+        "Guidance.TLabelframe",
+        background=DARK_PALETTE["surface"],
+        bordercolor=DARK_PALETTE["border"],
+        relief="solid",
+        borderwidth=1,
+        padding=(12, 10),
+    )
+    style.configure(
+        "Guidance.TLabelframe.Label",
+        background=DARK_PALETTE["surface"],
+        foreground=DARK_PALETTE["text"],
+        font=("Segoe UI", 11, "bold"),
+    )
+    style.configure(
+        "Section.TLabelframe",
+        background=DARK_PALETTE["surface"],
+        bordercolor=DARK_PALETTE["border"],
+        relief="solid",
+        borderwidth=1,
+        padding=(16, 12),
+    )
+    style.configure(
+        "Section.TLabelframe.Label",
+        background=DARK_PALETTE["surface"],
+        foreground=DARK_PALETTE["accent_alt"],
+        font=("Segoe UI", 11, "bold"),
+    )
+    style.configure(
+        "DashboardCard.TFrame",
+        background=DARK_PALETTE["surface"],
+        bordercolor=DARK_PALETTE["border"],
+        relief="solid",
+        borderwidth=1,
+        padding=(18, 16),
+    )
+    style.configure(
+        "ChartContainer.TFrame",
+        background=DARK_PALETTE["surface"],
+        bordercolor=DARK_PALETTE["border_muted"],
+        relief="solid",
+        borderwidth=1,
+        padding=(18, 16),
+    )
+    style.configure(
+        "CardHeading.TLabel",
+        background=DARK_PALETTE["surface"],
+        foreground=DARK_PALETTE["text_muted"],
+        font=("Segoe UI", 11, "bold"),
+    )
+    style.configure(
+        "MetricValue.TLabel",
+        background=DARK_PALETTE["surface"],
+        foreground=DARK_PALETTE["accent"],
+        font=("Segoe UI", 22, "bold"),
+    )
+    style.configure(
+        "MetricCaption.TLabel",
+        background=DARK_PALETTE["surface"],
+        foreground=DARK_PALETTE["text_muted"],
+        font=("Segoe UI", 10),
+    )
+    style.configure(
+        "Accent.TButton",
+        background=DARK_PALETTE["accent"],
+        foreground=DARK_PALETTE["canvas"],
+        bordercolor=DARK_PALETTE["accent"],
+        focusthickness=3,
+        focuscolor=DARK_PALETTE["accent_alt"],
+        padding=(16, 10),
+    )
+    style.configure(
+        "Neutral.TButton",
+        background=DARK_PALETTE["surface_alt"],
+        foreground=DARK_PALETTE["text"],
+        bordercolor=DARK_PALETTE["border"],
+        focusthickness=3,
+        focuscolor=DARK_PALETTE["accent_alt"],
+        padding=(14, 10),
+    )
+    style.map(
+        "Accent.TButton",
+        background=[
+            ("pressed", DARK_PALETTE["accent_active"]),
+            ("active", DARK_PALETTE["accent_hover"]),
+            ("disabled", DARK_PALETTE["border_muted"]),
+        ],
+        foreground=[
+            ("disabled", DARK_PALETTE["text_muted"]),
+            ("pressed", DARK_PALETTE["canvas"]),
+            ("active", DARK_PALETTE["canvas"]),
+        ],
+    )
+    style.map(
+        "Neutral.TButton",
+        background=[
+            ("pressed", DARK_PALETTE["surface_muted"]),
+            ("active", DARK_PALETTE["surface_alt"]),
+            ("disabled", DARK_PALETTE["border_muted"]),
+        ],
+        foreground=[
+            ("disabled", DARK_PALETTE["text_muted"]),
+        ],
+    )
+    style.configure(
+        "Input.TEntry",
+        fieldbackground=DARK_PALETTE["surface_alt"],
+        foreground=DARK_PALETTE["text"],
+        bordercolor=DARK_PALETTE["border"],
+        insertcolor=DARK_PALETTE["text"],
+    )
+    style.map(
+        "Input.TEntry",
+        fieldbackground=[
+            ("readonly", DARK_PALETTE["surface"]),
+            ("disabled", DARK_PALETTE["border_muted"]),
+        ],
+        foreground=[
+            ("disabled", DARK_PALETTE["text_muted"]),
+        ],
+    )
+    style.configure(
+        "Input.TCombobox",
+        fieldbackground=DARK_PALETTE["surface_alt"],
+        background=DARK_PALETTE["surface_alt"],
+        foreground=DARK_PALETTE["text"],
+        bordercolor=DARK_PALETTE["border"],
+    )
+    style.map(
+        "Input.TCombobox",
+        fieldbackground=[
+            ("readonly", DARK_PALETTE["surface_alt"]),
+            ("disabled", DARK_PALETTE["border_muted"]),
+        ],
+        foreground=[
+            ("disabled", DARK_PALETTE["text_muted"]),
+        ],
+    )
+    style.configure(
+        "Input.TSpinbox",
+        fieldbackground=DARK_PALETTE["surface_alt"],
+        foreground=DARK_PALETTE["text"],
+        bordercolor=DARK_PALETTE["border"],
+    )
+    style.map(
+        "Input.TSpinbox",
+        fieldbackground=[
+            ("disabled", DARK_PALETTE["border_muted"]),
+        ],
+        foreground=[
+            ("disabled", DARK_PALETTE["text_muted"]),
+        ],
+    )
+    style.configure(
+        "Input.TRadiobutton",
+        background=DARK_PALETTE["surface"],
+        foreground=DARK_PALETTE["text"],
+    )
+    style.map(
+        "Input.TRadiobutton",
+        foreground=[
+            ("disabled", DARK_PALETTE["text_muted"]),
+        ],
+    )
+    style.configure(
+        "Input.TCheckbutton",
+        background=DARK_PALETTE["surface"],
+        foreground=DARK_PALETTE["text"],
+    )
+    style.map(
+        "Input.TCheckbutton",
+        foreground=[
+            ("disabled", DARK_PALETTE["text_muted"]),
+        ],
+    )
+    style.configure(
+        "Accent.Horizontal.TProgressbar",
+        background=DARK_PALETTE["accent"],
+        troughcolor=DARK_PALETTE["surface"],
+        bordercolor=DARK_PALETTE["border"],
+    )
+
+    root.option_add("*TCombobox*Listbox.background", DARK_PALETTE["surface"])
+    root.option_add("*TCombobox*Listbox.foreground", DARK_PALETTE["text"])
+    root.option_add("*TCombobox*Listbox.selectBackground", DARK_PALETTE["accent"])
+    root.option_add("*TCombobox*Listbox.selectForeground", DARK_PALETTE["canvas"])
+
+    container = ttk.Frame(root, padding=16, style="AppContainer.TFrame")
     container.pack(fill=tk.BOTH, expand=True)
 
-    header = ttk.Frame(container)
+    header = ttk.Frame(container, style="DashboardBackground.TFrame")
     header.pack(fill=tk.X, pady=(0, 12))
-    ttk.Label(header, text="Project X · Manual Trading Copilot", style="Header.TLabel").pack(anchor=tk.W)
+    ttk.Label(
+        header, text="Project X · Manual Trading Copilot", style="Header.TLabel"
+    ).pack(anchor=tk.W)
     ttk.Label(
         header,
         text="Follow the guided workflow from credentials to Topstep-compliant trade plans.",
         style="SubHeader.TLabel",
     ).pack(anchor=tk.W)
 
-    guidance_card = ttk.Labelframe(container, text="Mission Checklist", style="Guidance.TLabelframe")
+    guidance_card = ttk.Labelframe(
+        container, text="Mission Checklist", style="Guidance.TLabelframe"
+    )
     guidance_card.pack(fill=tk.X, pady=(0, 12))
 
     step_label = ttk.Label(guidance_card, style="Step.TLabel")
     step_label.pack(anchor=tk.W)
-    progress = ttk.Progressbar(guidance_card, maximum=4, mode="determinate", length=220)
+    progress = ttk.Progressbar(
+        guidance_card,
+        maximum=1,
+        mode="determinate",
+        length=220,
+        style="Accent.Horizontal.TProgressbar",
+    )
     progress.pack(anchor=tk.W, pady=(8, 0))
 
     def handle_tab_change(index: int, name: str, guidance: str) -> None:
         step_label.config(text=f"{guidance}\n→ Current focus: {name} tab")
-        progress["value"] = index
+        progress.configure(value=min(index, float(progress.cget("maximum"))))
 
     notebook = ToptekApp(container, configs, paths, on_tab_change=handle_tab_change)
     notebook.pack(fill=tk.BOTH, expand=True)
+    tab_count = len(notebook.tabs())
+    if tab_count > 1:
+        progress.configure(maximum=float(tab_count - 1))
     notebook.initialise_guidance()
 
     root.mainloop()


### PR DESCRIPTION
## Summary
- introduce shared dark palette constants and text widget defaults for the GUI
- restyle the application bootstrap with dark theme widgets, hover maps, and a dashboard overview tab
- update the workflow tabs to use the new styles and document colour guidance for future contributors

## Testing
- ruff check .
- black .
- mypy toptek/gui
- pytest *(fails: missing optional dependencies such as numpy/pandas/sklearn in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a4303d808329adb4b98d3b9cbae5