### PR TITLE
Add UI configuration pipeline for shell and GUI defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,32 @@ The final `pip check` call should report "No broken requirements found",
 confirming that the pinned dependency set resolves without conflicts. Users on
 Python 3.12 should downgrade to Python 3.10/3.11 or wait for a dependency
 refresh that supports NumPy ≥1.28 and SciPy ≥1.12 before proceeding.
+
+## UI configuration surface
+
+The manual trading shell and Tkinter dashboard now read defaults from
+`configs/ui.yml`. The file ships with sensible demo values so the GUI renders
+without external data sources:
+
+- `appearance` &mdash; theme token (currently `dark`) and accent family used by the
+  style registry.
+- `shell` &mdash; defaults for the research symbol/timeframe, training lookback,
+  calibration flag, simulated backtest window, and preferred playbook.
+- `chart` &mdash; LiveChart refresh cadence (`fps`), point budget, and price
+  precision used by upcoming streaming widgets.
+- `status` &mdash; copy for the status banners shown in the Login, Train, Backtest,
+  and Guard tabs so product teams can retune messaging without touching code.
+
+Operators can override the YAML at runtime either with environment variables or
+CLI flags:
+
+- Environment variables follow the `TOPTEK_UI_*` convention, e.g.
+  `TOPTEK_UI_SYMBOL`, `TOPTEK_UI_INTERVAL`, `TOPTEK_UI_LOOKBACK_BARS`,
+  `TOPTEK_UI_CALIBRATE`, `TOPTEK_UI_FPS`, and `TOPTEK_UI_THEME`.
+- CLI switches (`--symbol`, `--timeframe`, `--lookback`, `--model`, `--fps`)
+  apply the same overrides for one-off runs and are reflected back into the GUI
+  when it launches.
+
+These controls keep the default Topstep demo intact while making it easy to
+point the toolkit at alternative markets or stress-test higher frequency charts
+without editing source files.

--- a/configs/ui.yml
+++ b/configs/ui.yml
@@ -1,0 +1,31 @@
+appearance:
+  theme: dark
+  accent: violet
+shell:
+  symbol: ES=F
+  interval: 5m
+  research_bars: 240
+  lookback_bars: 480
+  calibrate: true
+  model: logistic
+  simulation_bars: 720
+  playbook: momentum
+chart:
+  fps: 12
+  max_points: 180
+  price_decimals: 2
+status:
+  login:
+    idle: "Awaiting verification"
+    saved: "Saved. Run verification to confirm access."
+    verified: "All keys present. Proceed to Research ▶"
+  training:
+    idle: "Awaiting training run"
+    success: "Model artefact refreshed. Continue to Backtest ▶"
+  backtest:
+    idle: "No simulations yet"
+    success: "Sim complete. If expectancy holds, draft a manual trade plan ▶"
+  guard:
+    pending: "Topstep Guard: pending review"
+    intro: "Manual execution only. Awaiting guard refresh..."
+    defensive_warning: "DEFENSIVE_MODE active. Stand down and review your journal before trading."

--- a/tests/test_ui_config.py
+++ b/tests/test_ui_config.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+from pathlib import Path
+
+import pytest
+
+from core import ui_config
+
+
+def test_load_ui_config_defaults(tmp_path: Path) -> None:
+    path = tmp_path / "ui.yml"
+    path.write_text("{}\n", encoding="utf-8")
+    cfg = ui_config.load_ui_config(path, env={})
+    assert cfg.shell.symbol == "ES=F"
+    assert cfg.shell.interval == "5m"
+    assert cfg.shell.research_bars == 240
+    assert cfg.chart.fps == 12
+    assert cfg.status.login.idle == "Awaiting verification"
+    assert cfg.appearance.theme == "dark"
+
+
+def test_load_ui_config_env_overrides(tmp_path: Path) -> None:
+    path = tmp_path / "ui.yml"
+    path.write_text(
+        "shell:\n  symbol: ES=F\n  calibrate: true\nchart:\n  fps: 8\n",
+        encoding="utf-8",
+    )
+    env = {
+        "TOPTEK_UI_SYMBOL": "NQ=F",
+        "TOPTEK_UI_CALIBRATE": "false",
+        "TOPTEK_UI_LOOKBACK_BARS": "960",
+        "TOPTEK_UI_FPS": "24",
+        "TOPTEK_UI_THEME": "dark",
+    }
+    cfg = ui_config.load_ui_config(path, env=env)
+    assert cfg.shell.symbol == "NQ=F"
+    assert cfg.shell.calibrate is False
+    assert cfg.shell.lookback_bars == 960
+    assert cfg.chart.fps == 24
+    assert cfg.appearance.theme == "dark"
+
+
+def test_load_ui_config_validation(tmp_path: Path) -> None:
+    path = tmp_path / "ui.yml"
+    path.write_text("chart:\n  fps: 0\n", encoding="utf-8")
+    with pytest.raises(ValueError):
+        ui_config.load_ui_config(path, env={})

--- a/toptek/core/ui_config.py
+++ b/toptek/core/ui_config.py
@@ -1,0 +1,336 @@
+"""UI configuration parsing utilities with environment overrides."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict, dataclass, field, replace
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+from . import utils
+
+
+def _coerce_str(value: Any, field_name: str) -> str:
+    if value is None:
+        raise ValueError(f"{field_name} cannot be null")
+    return str(value)
+
+
+def _coerce_bool(value: Any, field_name: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    raise ValueError(f"{field_name} must be a boolean or boolean-like string")
+
+
+def _coerce_int(value: Any, field_name: str, *, minimum: int | None = None) -> int:
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+        raise ValueError(f"{field_name} must be an integer") from exc
+    if minimum is not None and coerced < minimum:
+        raise ValueError(f"{field_name} must be >= {minimum}")
+    return coerced
+
+
+@dataclass(frozen=True)
+class ShellSettings:
+    """Configuration for CLI shell defaults."""
+
+    symbol: str = "ES=F"
+    interval: str = "5m"
+    research_bars: int = 240
+    lookback_bars: int = 480
+    calibrate: bool = True
+    model: str = "logistic"
+    simulation_bars: int = 720
+    playbook: str = "momentum"
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "ShellSettings":
+        calibrate_raw = data.get("calibrate", cls.calibrate)
+        if isinstance(calibrate_raw, str):
+            calibrate_value = _coerce_bool(calibrate_raw, "shell.calibrate")
+        elif isinstance(calibrate_raw, bool):
+            calibrate_value = calibrate_raw
+        elif calibrate_raw is None:
+            calibrate_value = cls.calibrate
+        else:
+            calibrate_value = bool(calibrate_raw)
+        return cls(
+            symbol=_coerce_str(data.get("symbol", cls.symbol), "shell.symbol"),
+            interval=_coerce_str(data.get("interval", cls.interval), "shell.interval"),
+            research_bars=_coerce_int(
+                data.get("research_bars", cls.research_bars),
+                "shell.research_bars",
+                minimum=60,
+            ),
+            lookback_bars=_coerce_int(
+                data.get("lookback_bars", cls.lookback_bars),
+                "shell.lookback_bars",
+                minimum=120,
+            ),
+            calibrate=calibrate_value,
+            model=_coerce_str(data.get("model", cls.model), "shell.model"),
+            simulation_bars=_coerce_int(
+                data.get("simulation_bars", cls.simulation_bars),
+                "shell.simulation_bars",
+                minimum=120,
+            ),
+            playbook=_coerce_str(data.get("playbook", cls.playbook), "shell.playbook"),
+        )
+
+    def apply_environment(self, env: Mapping[str, str]) -> "ShellSettings":
+        updates: Dict[str, Any] = {}
+        if env.get("TOPTEK_UI_SYMBOL"):
+            updates["symbol"] = env["TOPTEK_UI_SYMBOL"]
+        if env.get("TOPTEK_UI_INTERVAL"):
+            updates["interval"] = env["TOPTEK_UI_INTERVAL"]
+        if env.get("TOPTEK_UI_RESEARCH_BARS"):
+            updates["research_bars"] = _coerce_int(
+                env["TOPTEK_UI_RESEARCH_BARS"],
+                "env.TOPTEK_UI_RESEARCH_BARS",
+                minimum=60,
+            )
+        if env.get("TOPTEK_UI_LOOKBACK_BARS"):
+            updates["lookback_bars"] = _coerce_int(
+                env["TOPTEK_UI_LOOKBACK_BARS"],
+                "env.TOPTEK_UI_LOOKBACK_BARS",
+                minimum=120,
+            )
+        if env.get("TOPTEK_UI_CALIBRATE"):
+            updates["calibrate"] = _coerce_bool(
+                env["TOPTEK_UI_CALIBRATE"], "env.TOPTEK_UI_CALIBRATE"
+            )
+        if env.get("TOPTEK_UI_MODEL"):
+            updates["model"] = env["TOPTEK_UI_MODEL"]
+        if env.get("TOPTEK_UI_SIMULATION_BARS"):
+            updates["simulation_bars"] = _coerce_int(
+                env["TOPTEK_UI_SIMULATION_BARS"],
+                "env.TOPTEK_UI_SIMULATION_BARS",
+                minimum=120,
+            )
+        if env.get("TOPTEK_UI_PLAYBOOK"):
+            updates["playbook"] = env["TOPTEK_UI_PLAYBOOK"]
+        return replace(self, **updates) if updates else self
+
+
+@dataclass(frozen=True)
+class ChartSettings:
+    """Chart refresh and theming parameters."""
+
+    fps: int = 12
+    max_points: int = 180
+    price_decimals: int = 2
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "ChartSettings":
+        return cls(
+            fps=_coerce_int(data.get("fps", cls.fps), "chart.fps", minimum=1),
+            max_points=_coerce_int(
+                data.get("max_points", cls.max_points), "chart.max_points", minimum=10
+            ),
+            price_decimals=_coerce_int(
+                data.get("price_decimals", cls.price_decimals),
+                "chart.price_decimals",
+                minimum=0,
+            ),
+        )
+
+    def apply_environment(self, env: Mapping[str, str]) -> "ChartSettings":
+        updates: Dict[str, Any] = {}
+        if env.get("TOPTEK_UI_FPS"):
+            updates["fps"] = _coerce_int(
+                env["TOPTEK_UI_FPS"], "env.TOPTEK_UI_FPS", minimum=1
+            )
+        if env.get("TOPTEK_UI_CHART_POINTS"):
+            updates["max_points"] = _coerce_int(
+                env["TOPTEK_UI_CHART_POINTS"], "env.TOPTEK_UI_CHART_POINTS", minimum=10
+            )
+        return replace(self, **updates) if updates else self
+
+
+@dataclass(frozen=True)
+class AppearanceSettings:
+    """High-level UI theming choices."""
+
+    theme: str = "dark"
+    accent: str = "violet"
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "AppearanceSettings":
+        return cls(
+            theme=_coerce_str(data.get("theme", cls.theme), "appearance.theme"),
+            accent=_coerce_str(data.get("accent", cls.accent), "appearance.accent"),
+        )
+
+    def apply_environment(self, env: Mapping[str, str]) -> "AppearanceSettings":
+        updates: Dict[str, Any] = {}
+        if env.get("TOPTEK_UI_THEME"):
+            updates["theme"] = env["TOPTEK_UI_THEME"]
+        if env.get("TOPTEK_UI_ACCENT"):
+            updates["accent"] = env["TOPTEK_UI_ACCENT"]
+        return replace(self, **updates) if updates else self
+
+
+@dataclass(frozen=True)
+class LoginStatus:
+    idle: str = "Awaiting verification"
+    saved: str = "Saved. Run verification to confirm access."
+    verified: str = "All keys present. Proceed to Research ▶"
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "LoginStatus":
+        return cls(
+            idle=_coerce_str(data.get("idle", cls.idle), "status.login.idle"),
+            saved=_coerce_str(data.get("saved", cls.saved), "status.login.saved"),
+            verified=_coerce_str(
+                data.get("verified", cls.verified), "status.login.verified"
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class TrainingStatus:
+    idle: str = "Awaiting training run"
+    success: str = "Model artefact refreshed. Continue to Backtest ▶"
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "TrainingStatus":
+        return cls(
+            idle=_coerce_str(data.get("idle", cls.idle), "status.training.idle"),
+            success=_coerce_str(
+                data.get("success", cls.success), "status.training.success"
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class BacktestStatus:
+    idle: str = "No simulations yet"
+    success: str = "Sim complete. If expectancy holds, draft a manual trade plan ▶"
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "BacktestStatus":
+        return cls(
+            idle=_coerce_str(data.get("idle", cls.idle), "status.backtest.idle"),
+            success=_coerce_str(
+                data.get("success", cls.success), "status.backtest.success"
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class GuardStatus:
+    pending: str = "Topstep Guard: pending review"
+    intro: str = "Manual execution only. Awaiting guard refresh..."
+    defensive_warning: str = (
+        "DEFENSIVE_MODE active. Stand down and review your journal before trading."
+    )
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "GuardStatus":
+        return cls(
+            pending=_coerce_str(
+                data.get("pending", cls.pending), "status.guard.pending"
+            ),
+            intro=_coerce_str(data.get("intro", cls.intro), "status.guard.intro"),
+            defensive_warning=_coerce_str(
+                data.get("defensive_warning", cls.defensive_warning),
+                "status.guard.defensive_warning",
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class StatusMessages:
+    login: LoginStatus = field(default_factory=LoginStatus)
+    training: TrainingStatus = field(default_factory=TrainingStatus)
+    backtest: BacktestStatus = field(default_factory=BacktestStatus)
+    guard: GuardStatus = field(default_factory=GuardStatus)
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "StatusMessages":
+        return cls(
+            login=LoginStatus.from_mapping(data.get("login", {})),
+            training=TrainingStatus.from_mapping(data.get("training", {})),
+            backtest=BacktestStatus.from_mapping(data.get("backtest", {})),
+            guard=GuardStatus.from_mapping(data.get("guard", {})),
+        )
+
+
+@dataclass(frozen=True)
+class UIConfig:
+    """Top-level structure for UI settings."""
+
+    appearance: AppearanceSettings = field(default_factory=AppearanceSettings)
+    shell: ShellSettings = field(default_factory=ShellSettings)
+    chart: ChartSettings = field(default_factory=ChartSettings)
+    status: StatusMessages = field(default_factory=StatusMessages)
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "UIConfig":
+        return cls(
+            appearance=AppearanceSettings.from_mapping(data.get("appearance", {})),
+            shell=ShellSettings.from_mapping(data.get("shell", {})),
+            chart=ChartSettings.from_mapping(data.get("chart", {})),
+            status=StatusMessages.from_mapping(data.get("status", {})),
+        )
+
+    def apply_environment(self, env: Mapping[str, str]) -> "UIConfig":
+        return replace(
+            self,
+            appearance=self.appearance.apply_environment(env),
+            shell=self.shell.apply_environment(env),
+            chart=self.chart.apply_environment(env),
+        )
+
+    def with_updates(
+        self,
+        *,
+        appearance: Dict[str, Any] | None = None,
+        shell: Dict[str, Any] | None = None,
+        chart: Dict[str, Any] | None = None,
+    ) -> "UIConfig":
+        """Return a copy of the config with provided section overrides."""
+
+        updates: Dict[str, Any] = {}
+        if appearance:
+            updates["appearance"] = replace(self.appearance, **appearance)
+        if shell:
+            updates["shell"] = replace(self.shell, **shell)
+        if chart:
+            updates["chart"] = replace(self.chart, **chart)
+        return replace(self, **updates) if updates else self
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "appearance": asdict(self.appearance),
+            "shell": asdict(self.shell),
+            "chart": asdict(self.chart),
+            "status": asdict(self.status),
+        }
+
+
+def load_ui_config(path: Path, *, env: Mapping[str, str] | None = None) -> UIConfig:
+    """Load :class:`UIConfig` from *path* applying environment overrides."""
+
+    env_mapping = os.environ if env is None else env
+    data = utils.load_yaml(path)
+    config = UIConfig.from_mapping(data)
+    return config.apply_environment(env_mapping)
+
+
+__all__ = [
+    "AppearanceSettings",
+    "ShellSettings",
+    "ChartSettings",
+    "StatusMessages",
+    "UIConfig",
+    "load_ui_config",
+]

--- a/toptek/main.py
+++ b/toptek/main.py
@@ -4,31 +4,53 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Tuple
 
 import numpy as np
 from dotenv import load_dotenv
 
-from core import backtest, data, model, risk, utils
+from core import backtest, data, model, risk, ui_config, utils
 from toptek.features import build_features
 
 
 ROOT = Path(__file__).parent
 
 
-def load_configs() -> Dict[str, Dict[str, object]]:
-    """Load configuration files into a dictionary."""
+def load_configs() -> Tuple[Dict[str, Dict[str, object]], ui_config.UIConfig]:
+    """Load configuration files along with UI defaults."""
 
     app_cfg = utils.load_yaml(ROOT / "config" / "app.yml")
     risk_cfg = utils.load_yaml(ROOT / "config" / "risk.yml")
     feature_cfg = utils.load_yaml(ROOT / "config" / "features.yml")
-    return {"app": app_cfg, "risk": risk_cfg, "features": feature_cfg}
+    ui_path = ROOT.parent / "configs" / "ui.yml"
+    ui_cfg = ui_config.load_ui_config(ui_path)
+    return (
+        {
+            "app": app_cfg,
+            "risk": risk_cfg,
+            "features": feature_cfg,
+            "ui": ui_cfg.as_dict(),
+        },
+        ui_cfg,
+    )
 
 
-def run_cli(args: argparse.Namespace, configs: Dict[str, Dict[str, object]], paths: utils.AppPaths) -> None:
+def run_cli(
+    args: argparse.Namespace,
+    configs: Dict[str, Dict[str, object]],
+    paths: utils.AppPaths,
+) -> None:
     """Dispatch CLI commands based on ``args``."""
 
     logger = utils.build_logger("toptek")
+    logger.info(
+        "CLI mode=%s symbol=%s timeframe=%s lookback=%s fps=%s",
+        args.cli,
+        args.symbol,
+        args.timeframe,
+        args.lookback,
+        getattr(args, "fps", None),
+    )
     risk_profile = risk.RiskProfile(
         max_position_size=configs["risk"].get("max_position_size", 1),
         max_daily_loss=configs["risk"].get("max_daily_loss", 1000),
@@ -38,7 +60,8 @@ def run_cli(args: argparse.Namespace, configs: Dict[str, Dict[str, object]], pat
         cooldown_minutes=configs["risk"].get("cooldown_minutes", 30),
     )
 
-    df = data.sample_dataframe()
+    lookback = int(args.lookback)
+    df = data.sample_dataframe(lookback)
     try:
         bundle = build_features(df, cache_dir=paths.cache)
     except ValueError as exc:
@@ -56,14 +79,22 @@ def run_cli(args: argparse.Namespace, configs: Dict[str, Dict[str, object]], pat
 
     if args.cli == "train":
         if np.unique(y).size < 2:
-            logger.error("Training aborted: dataset lacks class diversity after cleaning")
+            logger.error(
+                "Training aborted: dataset lacks class diversity after cleaning"
+            )
             return
         try:
-            result = model.train_classifier(X, y, model_type=args.model, models_dir=paths.models)
+            result = model.train_classifier(
+                X, y, model_type=args.model, models_dir=paths.models
+            )
         except ValueError as exc:
             logger.error("Training failed: %s", exc)
             return
-        logger.info("Training complete: metrics=%s threshold=%.2f", result.metrics, result.threshold)
+        logger.info(
+            "Training complete: metrics=%s threshold=%.2f",
+            result.metrics,
+            result.threshold,
+        )
     elif args.cli == "backtest":
         returns = np.log(df["close"]).diff().fillna(0).to_numpy()
         signals = (returns > 0).astype(int)
@@ -84,7 +115,9 @@ def run_cli(args: argparse.Namespace, configs: Dict[str, Dict[str, object]], pat
             if atr_series.size:
                 atr_value = float(atr_series[-1])
         if atr_value is None:
-            logger.warning("ATR14 feature unavailable from bundle; unable to size position")
+            logger.warning(
+                "ATR14 feature unavailable from bundle; unable to size position"
+            )
             return
         size = risk.position_size(
             account_balance=50000,
@@ -97,28 +130,99 @@ def run_cli(args: argparse.Namespace, configs: Dict[str, Dict[str, object]], pat
         logger.error("Unknown CLI command: %s", args.cli)
 
 
-def parse_args() -> argparse.Namespace:
-    """Parse command-line arguments."""
+def parse_args(settings: ui_config.UIConfig) -> argparse.Namespace:
+    """Parse command-line arguments with defaults sourced from ``settings``."""
 
     parser = argparse.ArgumentParser(description="Toptek manual trading toolkit")
-    parser.add_argument("--cli", choices=["train", "backtest", "paper"], help="Run in CLI mode instead of GUI")
-    parser.add_argument("--symbol", default="ESZ5", help="Futures symbol")
-    parser.add_argument("--timeframe", default="5m", help="Bar timeframe")
-    parser.add_argument("--lookback", default="90d", help="Lookback period for CLI commands")
-    parser.add_argument("--model", default="logistic", choices=["logistic", "gbm"], help="Model type for training")
+    parser.add_argument(
+        "--cli",
+        choices=["train", "backtest", "paper"],
+        help="Run in CLI mode instead of GUI",
+    )
+    parser.add_argument(
+        "--symbol",
+        help=f"Futures symbol (default: {settings.shell.symbol})",
+    )
+    parser.add_argument(
+        "--timeframe",
+        help=f"Bar timeframe (default: {settings.shell.interval})",
+    )
+    parser.add_argument(
+        "--lookback",
+        type=int,
+        help=f"Synthetic bar count for CLI flows (default: {settings.shell.lookback_bars})",
+    )
+    parser.add_argument(
+        "--model",
+        choices=["logistic", "gbm"],
+        help=f"Model type for training (default: {settings.shell.model})",
+    )
+    parser.add_argument(
+        "--fps",
+        type=int,
+        help=f"Live chart frames per second (default: {settings.chart.fps})",
+    )
     parser.add_argument("--start", help="Start date for backtest")
     return parser.parse_args()
+
+
+def _apply_cli_overrides(
+    settings: ui_config.UIConfig,
+    *,
+    symbol: str | None,
+    timeframe: str | None,
+    lookback: int | None,
+    model_name: str | None,
+    fps: int | None,
+) -> ui_config.UIConfig:
+    shell_updates: Dict[str, object] = {}
+    chart_updates: Dict[str, object] = {}
+    if symbol is not None:
+        shell_updates["symbol"] = symbol
+    if timeframe is not None:
+        shell_updates["interval"] = timeframe
+    if lookback is not None:
+        shell_updates["lookback_bars"] = lookback
+    if model_name is not None:
+        shell_updates["model"] = model_name
+    if fps is not None:
+        chart_updates["fps"] = fps
+    if not shell_updates and not chart_updates:
+        return settings
+    return settings.with_updates(
+        shell=shell_updates if shell_updates else None,
+        chart=chart_updates if chart_updates else None,
+    )
 
 
 def main() -> None:
     """Program entry point."""
 
     load_dotenv(ROOT / ".env")
-    configs = load_configs()
+    configs, ui_settings = load_configs()
     paths = utils.build_paths(ROOT, configs["app"])
     utils.ensure_directories(paths)
 
-    args = parse_args()
+    args = parse_args(ui_settings)
+    raw_symbol = args.symbol
+    raw_timeframe = args.timeframe
+    raw_lookback = args.lookback
+    raw_model = args.model
+    raw_fps = args.fps
+    args.symbol = raw_symbol or ui_settings.shell.symbol
+    args.timeframe = raw_timeframe or ui_settings.shell.interval
+    args.lookback = raw_lookback or ui_settings.shell.lookback_bars
+    args.model = raw_model or ui_settings.shell.model
+    args.fps = raw_fps or ui_settings.chart.fps
+    ui_settings = _apply_cli_overrides(
+        ui_settings,
+        symbol=raw_symbol,
+        timeframe=raw_timeframe,
+        lookback=raw_lookback,
+        model_name=raw_model,
+        fps=raw_fps,
+    )
+    configs["ui"] = ui_settings.as_dict()
     if args.cli:
         run_cli(args, configs, paths)
         return


### PR DESCRIPTION
## Summary
- introduce `configs/ui.yml` with appearance, shell, chart, and status defaults for the demo toolkit
- add `toptek/core/ui_config.py` to parse the YAML, apply environment/CLI overrides, and expose settings through `toptek.main`
- update the Tkinter widgets to source defaults and status copy from the UI config and add coverage for parsing/validation

## Testing
- `ruff check .`
- `black --check toptek/core/ui_config.py toptek/main.py toptek/gui/widgets.py tests/test_ui_config.py`
- `mypy --disable-error-code import-untyped toptek/core/ui_config.py toptek/main.py tests/test_ui_config.py`
- `pytest` *(fails: missing optional dependencies such as numpy/pandas/sklearn and PyYAML in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a95a63848329be8889df4c352ddd