### PR TITLE
Add numeric stack guardrail to Toptek entry point

### DIFF
--- a/tests/test_stack_guard.py
+++ b/tests/test_stack_guard.py
@@ -1,0 +1,75 @@
+"""Regression tests for the numeric stack guard in ``toptek.main``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+try:  # pragma: no cover - prefer site-packages import
+    from toptek.core import utils
+except ModuleNotFoundError:  # pragma: no cover - fallback when running from repo root
+    sys.path.insert(0, str(PROJECT_ROOT))
+    from toptek.core import utils
+
+
+class _DummyUI:
+    """Lightweight stand-in for :class:`UIConfig` used in tests."""
+
+    def __init__(self) -> None:
+        self.shell = type(
+            "Shell",
+            (),
+            {
+                "symbol": "ES",
+                "interval": "5m",
+                "lookback_bars": 100,
+                "model": "logistic",
+            },
+        )()
+        self.chart = type("Chart", (), {"fps": 12})()
+
+    def as_dict(self) -> Dict[str, object]:
+        return {}
+
+    def with_updates(self, **_updates):  # pragma: no cover - not exercised
+        return self
+
+
+@pytest.fixture(autouse=True)
+def _restore_argv(monkeypatch):
+    """Ensure tests run with a clean ``sys.argv``."""
+
+    original = list(sys.argv)
+    monkeypatch.setattr(sys, "argv", [sys.argv[0]])
+    yield
+    monkeypatch.setattr(sys, "argv", original)
+
+
+@pytest.fixture
+def patched_main(monkeypatch):
+    """Keep ``main`` deterministic when the guard allows execution."""
+
+    import toptek.main as main_module
+
+    def _fake_load_configs():
+        return {"app": {}, "risk": {}, "features": {}, "ui": {}}, _DummyUI()
+
+    monkeypatch.setattr(main_module, "load_configs", _fake_load_configs)
+    return main_module
+
+
+def test_main_surfaces_numeric_stack_error(monkeypatch, patched_main):
+    """Stack mismatch should raise a helpful RuntimeError before SciPy loads."""
+
+    monkeypatch.setitem(utils.STACK_REQUIREMENTS, "numpy", ">=999.0")
+    with pytest.raises(RuntimeError) as excinfo:
+        patched_main.main()
+    message = str(excinfo.value)
+    assert "Incompatible numeric stack" in message
+    assert "numpy" in message
+    assert "pip install -r toptek/requirements-lite.txt" in message

--- a/toptek/README.md
+++ b/toptek/README.md
@@ -64,6 +64,8 @@ Configuration defaults live under the `config/` folder and are merged with value
 
 - `requirements-lite.txt`: minimal dependencies for polling workflows. NumPy is capped below 1.28 so the bundled SciPy wheels stay importable; installing NumPy 2.x triggers a SciPy `ImportError` about missing manylinux-compatible binaries.
 - `requirements-streaming.txt`: extends the lite profile with optional SignalR streaming support.
+- On start-up `python -m toptek.main` validates that NumPy/SciPy/scikit-learn match the vetted wheels and raises a friendly
+  guidance error if the environment drifts. Reinstall with `pip install -r requirements-lite.txt` to resolve mismatches.
 
 ## Development notes
 


### PR DESCRIPTION
## Summary
- gate SciPy/sklearn-heavy modules behind a numeric stack guard in `toptek.main`
- add `utils.assert_numeric_stack` with friendly error messaging and regression coverage
- document the start-up guard behaviour in the README

## Testing
- ruff check toptek/main.py toptek/core/utils.py tests/test_stack_guard.py
- black --check toptek/main.py toptek/core/utils.py tests/test_stack_guard.py
- mypy --config-file mypy.ini toptek/main.py toptek/core/utils.py tests/test_stack_guard.py
- bandit -q -r toptek/main.py toptek/core/utils.py *(fails: command not found)*
- pytest *(fails: environment missing numpy/pandas/scikit-learn)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b418c6b08329b93889c7a39949ea