### PR TITLE
Fix TradeTab guard initialisation and add regression test

### DIFF
--- a/tests/gui/test_trade_tab.py
+++ b/tests/gui/test_trade_tab.py
@@ -1,0 +1,58 @@
+"""Regression tests for the Trade tab widget."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("numpy")
+pytest.importorskip("yaml")
+
+tk = pytest.importorskip("tkinter")
+from tkinter import ttk
+
+import toptek.core as core_package
+
+sys.modules.setdefault("core", core_package)
+
+from toptek.core import utils
+from toptek.gui.widgets import TradeTab
+
+
+def _paths(root: Path) -> utils.AppPaths:
+    return utils.AppPaths(root=root, cache=root / "cache", models=root / "models")
+
+
+def test_trade_tab_guard_initialises_with_configured_text(tmp_path: Path) -> None:
+    try:
+        root = tk.Tk()
+    except tk.TclError as exc:  # pragma: no cover - depends on CI environment
+        pytest.skip(f"Tk unavailable: {exc}")
+
+    root.withdraw()
+
+    notebook = ttk.Notebook(root)
+    notebook.pack()
+
+    guard_text = "Topstep Guard: ready"
+    configs: dict[str, dict[str, object]] = {
+        "ui": {
+            "status": {
+                "guard": {
+                    "pending": guard_text,
+                    "intro": "Guard intro text",
+                }
+            }
+        },
+        "risk": {},
+    }
+
+    tab = TradeTab(notebook, configs, _paths(tmp_path))
+
+    assert tab.guard_status.get() == guard_text
+    assert tab.guard_label is not None
+    assert tab.guard_label.cget("textvariable") == str(tab.guard_status)
+
+    root.destroy()

--- a/toptek/gui/widgets.py
+++ b/toptek/gui/widgets.py
@@ -833,12 +833,12 @@ class TradeTab(BaseTab):
         configs: Dict[str, Dict[str, object]],
         paths: utils.AppPaths,
     ) -> None:
+        super().__init__(master, configs, paths)
         guard_pending = self.ui_setting(
             "status", "guard", "pending", default="Topstep Guard: pending review"
         )
-        self.guard_status = tk.StringVar(value=guard_pending)
+        self.guard_status = tk.StringVar(master=self, value=guard_pending)
         self.guard_label: ttk.Label | None = None
-        super().__init__(master, configs, paths)
         self._build()
 
     def _build(self) -> None:


### PR DESCRIPTION
## Summary
- ensure TradeTab initialises its base tab before looking up UI settings
- initialise guard status after base class configuration is available
- add a regression test that exercises TradeTab creation with configured guard text

## Testing
- pytest tests/gui/test_trade_tab.py

------
https://chatgpt.com/codex/tasks/task_e_68e0b859eebc8329911c33218c054ceb