### PR TITLE
Add replay simulator and GUI integration

### DIFF
--- a/configs/ui.yml
+++ b/configs/ui.yml
@@ -29,3 +29,9 @@ status:
     pending: "Topstep Guard: pending review"
     intro: "Manual execution only. Awaiting guard refresh..."
     defensive_warning: "DEFENSIVE_MODE active. Stand down and review your journal before trading."
+  replay:
+    idle: "Load a dataset to begin playback."
+    buffering: "Preparing replay dataset..."
+    playing: "Streaming simulator feed."
+    paused: "Replay paused."
+    complete: "Reached end of recording."

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,4 @@
 [mypy]
 explicit_package_bases = True
 ignore_missing_imports = True
-files = toptek/gui
+files = toptek/gui,toptek/replay

--- a/tests/test_replay_speed.py
+++ b/tests/test_replay_speed.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pandas as pd
+import pytest
+
+from toptek.replay import ReplayBar, ReplaySimulator
+
+
+class VirtualClock:
+    """Deterministic clock used to capture simulated sleep durations."""
+
+    def __init__(self) -> None:
+        self.now: float = 0.0
+        self.history: list[float] = []
+
+    def sleep(self, seconds: float) -> None:
+        self.history.append(seconds)
+        self.now += seconds
+
+    def time(self) -> float:
+        return self.now
+
+
+def _sample_frame(rows: int) -> pd.DataFrame:
+    base = datetime(2024, 1, 1, 0, 0, 0)
+    timestamps = [base + timedelta(seconds=i) for i in range(rows)]
+    values = [float(i) for i in range(rows)]
+    return pd.DataFrame(
+        {
+            "timestamp": timestamps,
+            "open": values,
+            "high": [v + 0.5 for v in values],
+            "low": [v - 0.5 for v in values],
+            "close": [v + 0.25 for v in values],
+            "volume": [100 + i for i in range(rows)],
+        }
+    )
+
+
+def test_replay_scheduler_speed_adjustment() -> None:
+    rows = 600
+    frame = _sample_frame(rows)
+    clock = VirtualClock()
+    simulator = ReplaySimulator(
+        frame,
+        speed=12.0,
+        sleep=clock.sleep,
+        clock=clock.time,
+    )
+    observed: list[ReplayBar] = []
+    last_timestamp: datetime | None = None
+    expected_elapsed = 0.0
+    current_speed = 12.0
+
+    def _listener(bar: ReplayBar) -> None:
+        nonlocal last_timestamp, expected_elapsed, current_speed
+        if last_timestamp is not None:
+            delta = (bar.timestamp - last_timestamp).total_seconds()
+            expected_elapsed += delta / current_speed
+        last_timestamp = bar.timestamp
+        observed.append(bar)
+        if bar.index == 199:
+            current_speed = 24.0
+            simulator.set_speed(current_speed)
+        elif bar.index == 399:
+            current_speed = 6.0
+            simulator.set_speed(current_speed)
+
+    simulator.add_listener(_listener)
+    simulator.run()
+
+    assert len(observed) == rows
+    assert clock.now == pytest.approx(expected_elapsed, rel=1e-6)
+    assert len(clock.history) >= rows - 1

--- a/tests/test_ui_config.py
+++ b/tests/test_ui_config.py
@@ -15,6 +15,7 @@ def test_load_ui_config_defaults(tmp_path: Path) -> None:
     assert cfg.shell.research_bars == 240
     assert cfg.chart.fps == 12
     assert cfg.status.login.idle == "Awaiting verification"
+    assert cfg.status.replay.idle == "Load a dataset to begin playback."
     assert cfg.appearance.theme == "dark"
 
 

--- a/toptek/README.md
+++ b/toptek/README.md
@@ -26,6 +26,7 @@ python main.py
 python main.py --cli train --symbol ESZ5 --timeframe 5m --lookback 90d
 python main.py --cli backtest --symbol ESZ5 --timeframe 5m --start 2025-01-01
 python main.py --cli paper --symbol ESZ5 --timeframe 5m
+python -m toptek.replay.sim data/sessions/es_sample.parquet --speed 2.0
 ```
 
 ## Project structure
@@ -41,6 +42,8 @@ toptek/
     app.yml
     risk.yml
     features.yml
+  replay/
+    sim.py
   core/
     gateway.py
     symbols.py
@@ -69,10 +72,11 @@ Configuration defaults live under the `config/` folder and are merged with value
 
 ## Development notes
 
-- Source code is fully typed and documented with docstrings.
-- HTTP interactions with ProjectX Gateway rely on `httpx` with retry-once semantics for authentication failures.
-- Feature engineering uses `numpy` and `ta` indicators; additional features can be added to `core/features.py`.
-- Models are persisted locally in the `models/` folder.
+  - Source code is fully typed and documented with docstrings.
+  - HTTP interactions with ProjectX Gateway rely on `httpx` with retry-once semantics for authentication failures.
+  - Feature engineering uses `numpy` and `ta` indicators; additional features can be added to `core/features.py`.
+  - Models are persisted locally in the `models/` folder.
+  - The replay simulator (`toptek/replay/sim.py`) streams recorded bars into the GUI Replay tab and a standalone CLI (`python -m toptek.replay.sim`).
 
 ## Safety
 
@@ -89,4 +93,16 @@ pip install -r requirements-streaming.txt
 ```
 
 Streaming helpers are stubbed in `core/live.py` and disabled unless `signalrcore` is installed.
+
+## Replay simulator
+
+Use the Replay tab inside the GUI to connect a CSV/Parquet dataset to the live chart. Playback controls expose start, pause,
+resume, and seek, while a speed selector lets you accelerate or slow the stream. The same engine powers a CLI entry point:
+
+```bash
+python -m toptek.replay.sim path/to/session.parquet --speed 4 --format parquet
+```
+
+The CLI prints each bar as JSON and supports seeking via index or timestamp (`--seek 2024-01-15T14:30:00`). The GUI stores the
+most recent playback state in the in-memory config so mission control can resume from the same dataset.
 

--- a/toptek/core/ui_config.py
+++ b/toptek/core/ui_config.py
@@ -248,11 +248,37 @@ class GuardStatus:
 
 
 @dataclass(frozen=True)
+class ReplayStatus:
+    idle: str = "Load a dataset to begin playback."
+    buffering: str = "Preparing replay dataset..."
+    playing: str = "Streaming simulator feed."
+    paused: str = "Replay paused."
+    complete: str = "Reached end of recording."
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "ReplayStatus":
+        return cls(
+            idle=_coerce_str(data.get("idle", cls.idle), "status.replay.idle"),
+            buffering=_coerce_str(
+                data.get("buffering", cls.buffering), "status.replay.buffering"
+            ),
+            playing=_coerce_str(
+                data.get("playing", cls.playing), "status.replay.playing"
+            ),
+            paused=_coerce_str(data.get("paused", cls.paused), "status.replay.paused"),
+            complete=_coerce_str(
+                data.get("complete", cls.complete), "status.replay.complete"
+            ),
+        )
+
+
+@dataclass(frozen=True)
 class StatusMessages:
     login: LoginStatus = field(default_factory=LoginStatus)
     training: TrainingStatus = field(default_factory=TrainingStatus)
     backtest: BacktestStatus = field(default_factory=BacktestStatus)
     guard: GuardStatus = field(default_factory=GuardStatus)
+    replay: ReplayStatus = field(default_factory=ReplayStatus)
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> "StatusMessages":
@@ -261,6 +287,7 @@ class StatusMessages:
             training=TrainingStatus.from_mapping(data.get("training", {})),
             backtest=BacktestStatus.from_mapping(data.get("backtest", {})),
             guard=GuardStatus.from_mapping(data.get("guard", {})),
+            replay=ReplayStatus.from_mapping(data.get("replay", {})),
         )
 
 
@@ -330,6 +357,7 @@ __all__ = [
     "AppearanceSettings",
     "ShellSettings",
     "ChartSettings",
+    "ReplayStatus",
     "StatusMessages",
     "UIConfig",
     "load_ui_config",

--- a/toptek/gui/app.py
+++ b/toptek/gui/app.py
@@ -56,9 +56,13 @@ class ToptekApp(ttk.Notebook):
                 widgets.BacktestTab,
                 "Step 4 · Validate expectancy and drawdown resilience.",
             ),
+            "Replay": (
+                widgets.ReplayTab,
+                "Step 5 · Rehearse the playbook against recorded sessions before trading live.",
+            ),
             "Trade": (
                 widgets.TradeTab,
-                "Step 5 · Check Topstep guardrails and plan manual execution.",
+                "Step 6 · Check Topstep guardrails and plan manual execution.",
             ),
         }
         for name, (cls, guidance) in tabs.items():

--- a/toptek/replay/__init__.py
+++ b/toptek/replay/__init__.py
@@ -1,0 +1,5 @@
+"""Replay utilities for offline bar playback."""
+
+from .sim import ReplayBar, ReplaySimulator, detect_format
+
+__all__ = ["ReplayBar", "ReplaySimulator", "detect_format"]

--- a/toptek/replay/sim.py
+++ b/toptek/replay/sim.py
@@ -1,0 +1,394 @@
+"""Offline bar replay simulator with adjustable playback controls."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import threading
+import time
+from bisect import bisect_left
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from queue import Empty, SimpleQueue
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+import pandas as pd
+
+from toptek.core import utils
+
+ClockFn = Callable[[], float]
+SleepFn = Callable[[float], None]
+Listener = Callable[["ReplayBar"], None]
+
+
+@dataclass(frozen=True)
+class ReplayBar:
+    """Immutable container describing a replayed bar."""
+
+    index: int
+    timestamp: datetime
+    data: Dict[str, Any]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serialisable mapping containing the bar payload."""
+
+        payload = dict(self.data)
+        payload["timestamp"] = self.timestamp
+        payload["index"] = self.index
+        return payload
+
+
+def detect_format(path: Path, preferred: str | None = None) -> str:
+    """Return the dataset format inferred from *path* or *preferred*."""
+
+    if preferred and preferred.lower() != "auto":
+        normalised = preferred.lower()
+        if normalised not in {"csv", "parquet"}:
+            raise ValueError(f"Unsupported format override: {preferred}")
+        return normalised
+    suffix = path.suffix.lower()
+    if suffix in {".csv", ".txt"}:
+        return "csv"
+    if suffix in {".pq", ".parquet"}:
+        return "parquet"
+    raise ValueError(
+        "Unable to infer dataset format; pass --format csv|parquet explicitly"
+    )
+
+
+def _coerce_value(value: Any) -> Any:
+    if isinstance(value, pd.Timestamp):
+        return value.to_pydatetime()
+    if isinstance(value, (pd.Timedelta,)):
+        return value.to_pytimedelta()
+    if pd.isna(value):
+        return None
+    if hasattr(value, "item") and not isinstance(value, (bytes, bytearray)):
+        try:
+            return value.item()
+        except ValueError:
+            pass
+    return value
+
+
+class ReplaySimulator:
+    """Schedule and emit historical bars at configurable playback speeds."""
+
+    def __init__(
+        self,
+        data: pd.DataFrame,
+        *,
+        time_column: str = "timestamp",
+        speed: float = 1.0,
+        sleep: SleepFn | None = None,
+        clock: ClockFn | None = None,
+        max_step: float = 0.5,
+    ) -> None:
+        if data.empty:
+            raise ValueError("ReplaySimulator requires at least one bar")
+        if time_column not in data.columns:
+            raise ValueError(f"Missing time column: {time_column}")
+        timestamps = pd.to_datetime(data[time_column], utc=True)
+        if timestamps.isnull().any():
+            raise ValueError("Timestamp column contains null values")
+        ordered = data.assign(**{time_column: timestamps}).sort_values(time_column)
+        ordered = ordered.reset_index(drop=True)
+        records: List[Dict[str, Any]] = []
+        parsed_times: List[datetime] = []
+        for _, row in ordered.iterrows():
+            ts = row[time_column]
+            if isinstance(ts, pd.Timestamp):
+                ts = ts.to_pydatetime()
+            elif not isinstance(ts, datetime):
+                raise TypeError("Timestamp column must be datetime-like")
+            payload = {
+                column: _coerce_value(value)
+                for column, value in row.items()
+                if column != time_column
+            }
+            payload[time_column] = ts
+            records.append(payload)
+            parsed_times.append(ts)
+        self._records = records
+        self._timestamps = parsed_times
+        self._total = len(records)
+        self._listeners: List[Listener] = []
+        self._lock = threading.RLock()
+        self._speed = float(speed)
+        if self._speed <= 0:
+            raise ValueError("Speed multiplier must be positive")
+        self._sleep: SleepFn = sleep or time.sleep
+        self._clock: ClockFn = clock or time.perf_counter
+        self._max_step = max(0.01, float(max_step))
+        self._stop_event = threading.Event()
+        self._pause_event = threading.Event()
+        self._pause_event.set()
+        self._seek_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._running = False
+        self._next_index = 0
+        self._logger = utils.build_logger("ReplaySimulator")
+
+    @classmethod
+    def from_path(
+        cls,
+        path: str | Path,
+        *,
+        fmt: str | None = None,
+        time_column: str = "timestamp",
+        speed: float = 1.0,
+        limit: int | None = None,
+    ) -> "ReplaySimulator":
+        candidate = Path(path).expanduser().resolve()
+        if not candidate.exists():
+            raise FileNotFoundError(candidate)
+        dataset_format = detect_format(candidate, fmt)
+        if dataset_format == "csv":
+            frame = pd.read_csv(candidate)
+        else:
+            frame = pd.read_parquet(candidate)
+        if limit is not None:
+            if limit <= 0:
+                raise ValueError("limit must be positive")
+            frame = frame.iloc[: int(limit)]
+        if frame.empty:
+            raise ValueError("Replay dataset contains no rows")
+        return cls(frame, time_column=time_column, speed=speed)
+
+    @property
+    def total_bars(self) -> int:
+        return self._total
+
+    @property
+    def speed(self) -> float:
+        with self._lock:
+            return self._speed
+
+    @property
+    def running(self) -> bool:
+        return self._running
+
+    def add_listener(self, listener: Listener) -> None:
+        """Register *listener* for bar callbacks."""
+
+        with self._lock:
+            self._listeners.append(listener)
+
+    def clear_listeners(self) -> None:
+        with self._lock:
+            self._listeners.clear()
+
+    def set_speed(self, speed: float) -> None:
+        if speed <= 0:
+            raise ValueError("Speed multiplier must be positive")
+        with self._lock:
+            self._speed = float(speed)
+
+    def pause(self) -> None:
+        self._pause_event.clear()
+
+    def resume(self) -> None:
+        self._pause_event.set()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        self._pause_event.set()
+        self._seek_event.clear()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=1.0)
+        self._thread = None
+        self._running = False
+
+    def join(self, timeout: float | None = None) -> None:
+        thread = self._thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout)
+
+    def seek(self, target: int | float | datetime | str) -> None:
+        if self._total == 0:
+            return
+        index: int
+        if isinstance(target, int):
+            index = target
+        elif isinstance(target, float):
+            index = int(target * (self._total - 1))
+        elif isinstance(target, datetime):
+            index = bisect_left(self._timestamps, target)
+        elif isinstance(target, str):
+            parsed = pd.to_datetime(target, utc=True)
+            if pd.isna(parsed):
+                raise ValueError(f"Unable to parse seek timestamp: {target}")
+            index = bisect_left(self._timestamps, parsed.to_pydatetime())
+        else:
+            raise TypeError("Seek target must be int, float, datetime, or str")
+        index = max(0, min(index, self._total - 1))
+        with self._lock:
+            self._next_index = index
+        self._seek_event.set()
+        self._pause_event.set()
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            raise RuntimeError("Replay already running")
+        self._stop_event.clear()
+        self._pause_event.set()
+        with self._lock:
+            if self._next_index >= self._total:
+                self._next_index = 0
+        self._seek_event.clear()
+        self._thread = threading.Thread(target=self._run_loop, daemon=True)
+        self._thread.start()
+
+    def run(self) -> None:
+        if self._running:
+            raise RuntimeError("Replay already running")
+        self._stop_event.clear()
+        self._pause_event.set()
+        with self._lock:
+            if self._next_index >= self._total:
+                self._next_index = 0
+        self._seek_event.clear()
+        self._run_loop()
+
+    def _emit(self, index: int, payload: Dict[str, Any]) -> None:
+        bar = ReplayBar(index=index, timestamp=self._timestamps[index], data=payload)
+        listeners: List[Listener]
+        with self._lock:
+            listeners = list(self._listeners)
+        for listener in listeners:
+            try:
+                listener(bar)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                self._logger.exception("Replay listener failed: %s", exc)
+
+    def _run_loop(self) -> None:
+        self._running = True
+        cursor = -1
+        last_timestamp: datetime | None = None
+        try:
+            while not self._stop_event.is_set():
+                if not self._pause_event.wait(timeout=0.1):
+                    continue
+                with self._lock:
+                    target = self._next_index
+                if target >= self._total:
+                    break
+                if target != cursor:
+                    cursor = target
+                    last_timestamp = None
+                payload = self._records[cursor]
+                current_timestamp = self._timestamps[cursor]
+                if last_timestamp is not None:
+                    delta = (current_timestamp - last_timestamp).total_seconds()
+                    if delta > 0:
+                        self._wait(delta)
+                    if self._stop_event.is_set():
+                        break
+                    if self._seek_event.is_set():
+                        self._seek_event.clear()
+                        last_timestamp = None
+                        continue
+                self._emit(cursor, payload)
+                last_timestamp = current_timestamp
+                cursor += 1
+                with self._lock:
+                    self._next_index = cursor
+                if cursor >= self._total:
+                    break
+        finally:
+            self._running = False
+            self._stop_event.set()
+            self._pause_event.set()
+
+    def _wait(self, bar_seconds: float) -> None:
+        remaining = max(bar_seconds, 0.0)
+        while remaining > 1e-6 and not self._stop_event.is_set():
+            if not self._pause_event.wait(timeout=0.05):
+                continue
+            if self._seek_event.is_set():
+                break
+            with self._lock:
+                speed = self._speed
+            speed = max(speed, 1e-6)
+            real_chunk = min(remaining / speed, self._max_step)
+            if real_chunk <= 0:
+                break
+            start = self._clock()
+            self._sleep(real_chunk)
+            elapsed = max(self._clock() - start, real_chunk)
+            remaining -= elapsed * speed
+            if self._seek_event.is_set():
+                break
+
+
+def _queue_listener(queue: SimpleQueue[ReplayBar]) -> Listener:
+    def _listener(bar: ReplayBar) -> None:
+        queue.put(bar)
+
+    return _listener
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Play back historical bars")
+    parser.add_argument("path", help="CSV or Parquet file containing bars")
+    parser.add_argument("--format", choices=["auto", "csv", "parquet"], default="auto")
+    parser.add_argument(
+        "--speed", type=float, default=1.0, help="Playback speed multiplier"
+    )
+    parser.add_argument(
+        "--time-column",
+        default="timestamp",
+        help="Name of the timestamp column (default: timestamp)",
+    )
+    parser.add_argument(
+        "--seek",
+        help="Seek to a zero-based index or ISO8601 timestamp before playback starts",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="Optional maximum number of bars to stream",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    try:
+        simulator = ReplaySimulator.from_path(
+            args.path,
+            fmt=args.format,
+            time_column=args.time_column,
+            speed=args.speed,
+            limit=args.limit,
+        )
+    except Exception as exc:  # pragma: no cover - CLI entry point
+        print(f"Error: {exc}")
+        return 1
+    queue: SimpleQueue[ReplayBar] = SimpleQueue()
+    simulator.add_listener(_queue_listener(queue))
+    if args.seek:
+        try:
+            if args.seek.isdigit():
+                simulator.seek(int(args.seek))
+            else:
+                simulator.seek(args.seek)
+        except Exception as exc:  # pragma: no cover - CLI guard
+            print(f"Seek ignored: {exc}")
+    simulator.start()
+    try:
+        while simulator.running or not queue.empty():
+            try:
+                bar = queue.get(timeout=0.25)
+            except Empty:
+                continue
+            print(json.dumps(bar.to_dict(), default=str))
+    except KeyboardInterrupt:  # pragma: no cover - interactive guard
+        simulator.stop()
+    finally:
+        simulator.stop()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI bootstrap
+    raise SystemExit(main())
+
+
+__all__ = ["ReplayBar", "ReplaySimulator", "detect_format", "main"]


### PR DESCRIPTION
## Summary
- add a replay simulator package that replays CSV or Parquet bars with speed, pause, and seek controls plus a `python -m toptek.replay.sim` CLI
- introduce a Replay tab that streams simulator output into a live chart with dataset browsing, playback controls, and mission status updates
- extend UI status/config defaults and documentation for replay workflows and cover scheduler timing with a dedicated pytest

## Testing
- ruff check toptek/replay/sim.py toptek/replay/__init__.py toptek/gui/widgets.py toptek/gui/app.py toptek/core/ui_config.py tests/test_replay_speed.py tests/test_ui_config.py
- mypy
- pytest *(fails: missing pandas/numpy/sklearn/yaml in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0bca8c0f48329add4e1ada3321c8a