### PR TITLE
Fix replay CLI queue polling race condition

### DIFF
--- a/tests/test_replay_cli.py
+++ b/tests/test_replay_cli.py
@@ -53,9 +53,8 @@ class DummySimulator:
         self._listeners.append(listener)
 
     def start(self) -> None:
-        self._running = True
-
         def _worker() -> None:
+            self._running = True
             for bar in self._bars:
                 time.sleep(0.01)
                 for listener in list(self._listeners):
@@ -91,6 +90,7 @@ def dummy_replay(monkeypatch) -> DummySimulator:
 
 
 def test_main_replays_and_prints_bars(dummy_replay: DummySimulator, capsys) -> None:
+    assert dummy_replay.running is False
     exit_code = sim.main(["dummy-path.csv"])
 
     dummy_replay.stop()

--- a/toptek/replay/sim.py
+++ b/toptek/replay/sim.py
@@ -375,8 +375,6 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
     simulator.start()
     try:
         while True:
-            if not simulator.running and queue.empty():
-                break
             try:
                 bar = queue.get(timeout=0.25)
             except Empty:


### PR DESCRIPTION
## Summary
- ensure the replay CLI consumes from the queue before checking the shutdown condition so slow-starting simulators still emit bars
- tighten the CLI termination check to run only after a failed poll
- update the replay CLI test double to match the simulator startup semantics and assert coverage for the regression

## Testing
- pytest tests/test_replay_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68e0cb32faa4832990ac62ed12835744