### PR TITLE
Add risk guard engine and trade tab safeguards

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,18 @@ CLI flags:
 These controls keep the default Topstep demo intact while making it easy to
 point the toolkit at alternative markets or stress-test higher frequency charts
 without editing source files.
+
+## Risk guard engine
+
+The `toptek/risk` package now ships a policy-driven guard engine that powers
+the trade tab badge and the `Ctrl+P` panic circuit. Run
+
+```bash
+python -m toptek.risk.engine --dryrun
+```
+
+to inspect the aggregated guard report and rule breakdown without launching the
+GUI. Install [`PyYAML`](https://pyyaml.org/) if the command reports a missing
+dependency. The same report is serialised back into the `configs["trade"]`
+dictionary whenever the guard is refreshed, allowing downstream automation to
+respond when the status shifts between `OK` and `DEFENSIVE_MODE`.

--- a/tests/gui/test_trade_tab.py
+++ b/tests/gui/test_trade_tab.py
@@ -11,14 +11,15 @@ pytest.importorskip("numpy")
 pytest.importorskip("yaml")
 
 tk = pytest.importorskip("tkinter")
-from tkinter import ttk
+from tkinter import ttk  # noqa: E402
 
-import toptek.core as core_package
+import toptek.core as core_package  # noqa: E402
 
 sys.modules.setdefault("core", core_package)
 
-from toptek.core import utils
-from toptek.gui.widgets import TradeTab
+from toptek.core import utils  # noqa: E402
+from toptek.gui import DARK_PALETTE  # noqa: E402
+from toptek.gui.widgets import TradeTab  # noqa: E402
 
 
 def _paths(root: Path) -> utils.AppPaths:
@@ -51,8 +52,151 @@ def test_trade_tab_guard_initialises_with_configured_text(tmp_path: Path) -> Non
 
     tab = TradeTab(notebook, configs, _paths(tmp_path))
 
-    assert tab.guard_status.get() == guard_text
+    assert tab.guard_status.get() == f"{guard_text} · Mode PAPER"
     assert tab.guard_label is not None
     assert tab.guard_label.cget("textvariable") == str(tab.guard_status)
+
+    root.destroy()
+
+
+def test_trade_tab_guard_refresh_updates_badge_and_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    try:
+        root = tk.Tk()
+    except tk.TclError as exc:  # pragma: no cover - depends on CI environment
+        pytest.skip(f"Tk unavailable: {exc}")
+
+    root.withdraw()
+
+    notebook = ttk.Notebook(root)
+    notebook.pack()
+
+    configs: dict[str, dict[str, object]] = {
+        "ui": {"status": {"guard": {"pending": "Topstep Guard: pending"}}},
+        "risk": {},
+    }
+    tab = TradeTab(notebook, configs, _paths(tmp_path))
+    monkeypatch.setattr(
+        "toptek.gui.widgets.messagebox.showinfo", lambda *args, **kwargs: None
+    )
+
+    report = tab._refresh_guard(show_modal=False)
+
+    assert report.status == "OK"
+    assert tab.guard_status.get() == "Topstep Guard: OK · Mode PAPER"
+    assert tab.guard_label is not None
+    assert tab.guard_label.cget("foreground") == DARK_PALETTE["success"]
+
+    payload = tab.output.get("1.0", "end-1c")
+    assert '"status": "OK"' in payload
+    assert configs["trade"]["report"]["status"] == "OK"
+
+    root.destroy()
+
+
+def test_trade_tab_guard_refresh_trips_defensive_when_policy_breached(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    try:
+        root = tk.Tk()
+    except tk.TclError as exc:  # pragma: no cover - depends on CI environment
+        pytest.skip(f"Tk unavailable: {exc}")
+
+    root.withdraw()
+
+    notebook = ttk.Notebook(root)
+    notebook.pack()
+
+    configs: dict[str, dict[str, object]] = {
+        "ui": {"status": {"guard": {"pending": "Guard pending"}}},
+        "risk": {"max_position_size": 0, "max_daily_loss": 10000},
+    }
+    tab = TradeTab(notebook, configs, _paths(tmp_path))
+    monkeypatch.setattr(
+        "toptek.gui.widgets.messagebox.showwarning", lambda *args, **kwargs: None
+    )
+
+    report = tab._refresh_guard(show_modal=False)
+
+    assert report.status == "DEFENSIVE_MODE"
+    assert tab.guard_status.get() == "Topstep Guard: DEFENSIVE_MODE · Mode PAPER"
+    assert tab.guard_label is not None
+    assert tab.guard_label.cget("foreground") == DARK_PALETTE["danger"]
+
+    payload = tab.output.get("1.0", "end-1c")
+    assert '"DEFENSIVE_MODE"' in payload
+    assert configs["trade"]["report"]["status"] == "DEFENSIVE_MODE"
+
+    root.destroy()
+
+
+def test_trade_tab_live_mode_requires_confirmation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    try:
+        root = tk.Tk()
+    except tk.TclError as exc:  # pragma: no cover - depends on CI environment
+        pytest.skip(f"Tk unavailable: {exc}")
+
+    root.withdraw()
+
+    notebook = ttk.Notebook(root)
+    notebook.pack()
+
+    configs: dict[str, dict[str, object]] = {
+        "ui": {"status": {"guard": {"pending": "Guard pending"}}},
+        "risk": {},
+    }
+    tab = TradeTab(notebook, configs, _paths(tmp_path))
+
+    monkeypatch.setattr(
+        "toptek.gui.widgets.messagebox.askyesno", lambda *args, **kwargs: False
+    )
+    tab._set_mode("LIVE")
+    assert tab.trading_mode.get() == "PAPER"
+    assert tab.guard_status.get().endswith("Mode PAPER")
+
+    monkeypatch.setattr(
+        "toptek.gui.widgets.messagebox.askyesno", lambda *args, **kwargs: True
+    )
+    tab._set_mode("LIVE")
+    assert tab.trading_mode.get() == "LIVE"
+    assert tab.guard_status.get().endswith("Mode LIVE")
+    assert configs["trade"]["mode"] == "LIVE"
+
+    root.destroy()
+
+
+def test_trade_tab_panic_hotkey_forces_paper(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    try:
+        root = tk.Tk()
+    except tk.TclError as exc:  # pragma: no cover - depends on CI environment
+        pytest.skip(f"Tk unavailable: {exc}")
+
+    root.withdraw()
+
+    notebook = ttk.Notebook(root)
+    notebook.pack()
+
+    configs: dict[str, dict[str, object]] = {
+        "ui": {"status": {"guard": {"pending": "Guard pending"}}},
+        "risk": {},
+    }
+    tab = TradeTab(notebook, configs, _paths(tmp_path))
+    monkeypatch.setattr(
+        "toptek.gui.widgets.messagebox.askyesno", lambda *args, **kwargs: True
+    )
+    tab._set_mode("LIVE")
+    assert tab.trading_mode.get() == "LIVE"
+
+    tab._handle_panic(None)
+
+    assert tab.trading_mode.get() == "PAPER"
+    assert tab.guard_status.get().endswith("Mode PAPER")
+    assert configs["trade"]["mode"] == "PAPER"
+    assert "panic_at" in configs["trade"]
 
     root.destroy()

--- a/tests/test_replay_cli.py
+++ b/tests/test_replay_cli.py
@@ -15,6 +15,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 if "pandas" not in sys.modules:
+
     def _unsupported(*_: object, **__: object) -> None:
         raise RuntimeError("pandas stub used unexpectedly")
 
@@ -33,8 +34,8 @@ if "yaml" not in sys.modules:
     yaml_stub = types.SimpleNamespace(safe_load=lambda *args, **kwargs: {})
     sys.modules["yaml"] = yaml_stub  # type: ignore[assignment]
 
-from toptek.replay import sim
-from toptek.replay.sim import ReplayBar
+from toptek.replay import sim  # noqa: E402
+from toptek.replay.sim import ReplayBar  # noqa: E402
 
 
 class DummySimulator:

--- a/tests/test_risk_engine.py
+++ b/tests/test_risk_engine.py
@@ -1,0 +1,37 @@
+"""Unit tests for the Toptek risk engine."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("yaml")
+
+from toptek.risk import RiskEngine
+
+
+@pytest.mark.parametrize(
+    "overrides,expected_status",
+    [
+        ({}, "OK"),
+        ({"max_daily_loss": 10000}, "DEFENSIVE_MODE"),
+        ({"max_position_size": 0}, "DEFENSIVE_MODE"),
+    ],
+)
+def test_risk_engine_evaluate_respects_policy(overrides, expected_status):
+    engine = RiskEngine.from_policy()
+    profile = engine.build_profile(overrides)
+    report = engine.evaluate(profile)
+    assert report.status == expected_status
+    assert report.to_dict()["status"] == expected_status
+    assert isinstance(report.suggested_contracts, int)
+    assert report.rules
+
+
+def test_risk_engine_cli_dryrun_outputs_report(capsys):
+    from toptek.risk.engine import main
+
+    exit_code = main(["--dryrun"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Guard policy" in captured.out
+    assert "Overall status" in captured.out

--- a/toptek/gui/README.md
+++ b/toptek/gui/README.md
@@ -35,9 +35,10 @@ constants exposed in `toptek/gui/__init__.py`.
 - **Typography styles** – `Header.TLabel`, `SubHeader.TLabel`, `Body.TLabel`,
   `Surface.TLabel`, `CardHeading.TLabel`, `MetricValue.TLabel`, and
   `MetricCaption.TLabel` keep copy aligned with the light-on-dark palette.
-- **Status styles** – `StatusInfo.TLabel` (for canvas backgrounds) and
-  `SurfaceStatus.TLabel` (for raised surfaces) hold highlights such as
-  verification outcomes and guard readiness.
+- **Status styles** – `StatusInfo.TLabel` (for canvas backgrounds),
+  `SurfaceStatus.TLabel` (for raised surfaces), and `GuardBadge.TLabel`
+  (compact guard chip) hold highlights such as verification outcomes and
+  guard readiness.
 - **Input styles** – `Input.TEntry`, `Input.TCombobox`, `Input.TSpinbox`,
   `Input.TRadiobutton`, and `Input.TCheckbutton` provide consistent field
   surfaces while default buttons consume either `Accent.TButton` (primary
@@ -67,7 +68,9 @@ constants exposed in `toptek/gui/__init__.py`.
    existing pattern: `DashboardCard.TFrame` containers with a heading label,
    `MetricValue.TLabel` for the primary figure, and `MetricCaption.TLabel` for
    the descriptive copy. Charts and rich panes should sit inside
-   `ChartContainer.TFrame` to inherit border and padding rules.
+   `ChartContainer.TFrame` to inherit border and padding rules. Guard status
+   surfaces should update the `GuardBadge.TLabel` copy instead of painting
+   ad-hoc colours so downstream tooling can parse guard transitions.
 
 ## Extending the theme
 

--- a/toptek/gui/app.py
+++ b/toptek/gui/app.py
@@ -201,6 +201,13 @@ def launch_app(*, configs: Dict[str, Dict[str, object]], paths: utils.AppPaths) 
         font=("Segoe UI", 10, "bold"),
     )
     style.configure(
+        "GuardBadge.TLabel",
+        background=DARK_PALETTE["surface_alt"],
+        foreground=DARK_PALETTE["accent_alt"],
+        font=("Segoe UI", 10, "bold"),
+        padding=(12, 4),
+    )
+    style.configure(
         "Guidance.TLabelframe",
         background=DARK_PALETTE["surface"],
         bordercolor=DARK_PALETTE["border"],

--- a/toptek/risk/__init__.py
+++ b/toptek/risk/__init__.py
@@ -1,0 +1,11 @@
+"""Toptek risk guard policy utilities."""
+
+from __future__ import annotations
+
+from .engine import GuardReport, GuardRuleResult, RiskEngine
+
+__all__ = [
+    "GuardReport",
+    "GuardRuleResult",
+    "RiskEngine",
+]

--- a/toptek/risk/engine.py
+++ b/toptek/risk/engine.py
@@ -1,0 +1,292 @@
+"""Guard policy loader and evaluation helpers for Toptek risk."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Mapping, MutableMapping, Sequence
+
+try:
+    import yaml  # type: ignore[import]
+except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+    raise RuntimeError(
+        "PyYAML is required to load guard policies. Install it with 'pip install pyyaml'."
+    ) from exc
+
+from toptek.core import risk as core_risk
+
+_POLICY_FILENAME = "policy.yml"
+_GUARD_OK = "OK"
+_GUARD_DEFENSIVE = "DEFENSIVE_MODE"
+
+
+@dataclass(frozen=True)
+class GuardRuleResult:
+    """Outcome for a single guard policy rule."""
+
+    rule_id: str
+    title: str
+    status: str
+    message: str
+
+    def to_dict(self) -> Dict[str, str]:
+        """Serialise the rule outcome into a dictionary."""
+
+        return {
+            "id": self.rule_id,
+            "title": self.title,
+            "status": self.status,
+            "message": self.message,
+        }
+
+
+@dataclass(frozen=True)
+class GuardReport:
+    """Aggregate output produced by :class:`RiskEngine`."""
+
+    status: str
+    rules: list[GuardRuleResult]
+    suggested_contracts: int
+    account_balance: float
+    policy_version: str | None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-serialisable representation of the report."""
+
+        return {
+            "status": self.status,
+            "suggested_contracts": self.suggested_contracts,
+            "account_balance": self.account_balance,
+            "policy_version": self.policy_version,
+            "rules": [rule.to_dict() for rule in self.rules],
+        }
+
+
+class RiskEngine:
+    """Loads and evaluates the static guard policy."""
+
+    def __init__(self, policy: Mapping[str, Any], policy_path: Path) -> None:
+        self._policy = dict(policy)
+        self._policy_path = policy_path
+        self._rules: list[Mapping[str, Any]] = list(policy.get("rules", []))
+        self._defaults: MutableMapping[str, Any] = dict(policy.get("defaults", {}))
+        self._profile_defaults: MutableMapping[str, Any] = dict(
+            policy.get("profile", {})
+        )
+        self._policy_metadata = {
+            "name": policy.get("name", "Toptek guard policy"),
+            "version": policy.get("version"),
+            "path": str(policy_path),
+        }
+
+    @classmethod
+    def from_policy(cls, path: Path | None = None) -> "RiskEngine":
+        """Construct the engine from ``policy.yml`` or *path* if provided."""
+
+        if path is None:
+            path = Path(__file__).with_name(_POLICY_FILENAME)
+        policy_text = path.read_text(encoding="utf-8")
+        loaded = yaml.safe_load(policy_text)
+        if not isinstance(loaded, Mapping):  # pragma: no cover - defensive guard
+            raise ValueError("Guard policy must deserialize to a mapping")
+        return cls(loaded, path)
+
+    @property
+    def defaults(self) -> Mapping[str, Any]:
+        """Return numeric defaults used during evaluation."""
+
+        return self._defaults
+
+    @property
+    def policy_metadata(self) -> Mapping[str, Any]:
+        """Expose static metadata about the currently loaded policy."""
+
+        return self._policy_metadata
+
+    def _default_float(self, key: str, fallback: float = 0.0) -> float:
+        return _coerce_float(self._defaults.get(key), fallback)
+
+    def build_profile(
+        self, overrides: Mapping[str, Any] | None = None
+    ) -> core_risk.RiskProfile:
+        """Create a :class:`~toptek.core.risk.RiskProfile` from defaults + overrides."""
+
+        data: Dict[str, Any] = dict(self._profile_defaults)
+        if overrides:
+            data.update(overrides)
+        restricted_hours = [dict(window) for window in data.get("restricted_hours", [])]
+        return core_risk.RiskProfile(
+            max_position_size=int(data.get("max_position_size", 1)),
+            max_daily_loss=float(data.get("max_daily_loss", 1000)),
+            restricted_hours=restricted_hours,
+            atr_multiplier_stop=float(data.get("atr_multiplier_stop", 2.0)),
+            cooldown_losses=int(data.get("cooldown_losses", 2)),
+            cooldown_minutes=int(data.get("cooldown_minutes", 30)),
+        )
+
+    def evaluate(
+        self,
+        profile: core_risk.RiskProfile,
+        *,
+        account_balance: float | None = None,
+        atr: float | None = None,
+        tick_value: float | None = None,
+        risk_per_trade: float | None = None,
+    ) -> GuardReport:
+        """Run the configured guard checks for *profile* and return a report."""
+
+        balance_default = self._default_float("account_balance")
+        atr_default = self._default_float("atr")
+        tick_default = self._default_float("tick_value")
+        risk_default = self._default_float("risk_per_trade")
+        balance = _coerce_float(account_balance, balance_default)
+        atr_value = _coerce_float(atr, atr_default)
+        tick = _coerce_float(tick_value, tick_default)
+        risk_fraction = _coerce_float(risk_per_trade, risk_default)
+        suggested = core_risk.position_size(
+            balance,
+            profile,
+            atr=atr_value,
+            tick_value=tick,
+            risk_per_trade=risk_fraction,
+        )
+        results: list[GuardRuleResult] = []
+        worst_status = _GUARD_OK
+        for rule in self._rules:
+            outcome = self._evaluate_rule(rule, profile, suggested)
+            results.append(outcome)
+            if outcome.status != _GUARD_OK:
+                worst_status = _GUARD_DEFENSIVE
+        return GuardReport(
+            status=worst_status,
+            rules=results,
+            suggested_contracts=suggested,
+            account_balance=balance,
+            policy_version=self._policy_metadata.get("version"),
+        )
+
+    def render_report(self, report: GuardReport) -> str:
+        """Return a human readable representation of *report*."""
+
+        lines = [
+            f"Guard policy: {self._policy_metadata.get('name')}"
+            f" (version {report.policy_version or 'n/a'})",
+            f"Policy file: {self._policy_metadata.get('path')}",
+            f"Account balance assumption: ${report.account_balance:,.2f}",
+            f"Suggested contracts: {report.suggested_contracts}",
+            f"Overall status: {report.status}",
+            "",
+            "Rule breakdown:",
+        ]
+        for rule in report.rules:
+            lines.append(f"- [{rule.status}] {rule.title}: {rule.message}")
+        return "\n".join(lines)
+
+    def _evaluate_rule(
+        self,
+        rule: Mapping[str, Any],
+        profile: core_risk.RiskProfile,
+        suggested_contracts: int,
+    ) -> GuardRuleResult:
+        rule_id = str(rule.get("id", "rule"))
+        title = str(rule.get("title", rule_id.replace("-", " ").title()))
+        rule_type = str(rule.get("type", "position_size"))
+        ok_template = str(rule.get("ok", "Guard ready."))
+        defensive_template = str(
+            rule.get(
+                "defensive",
+                "Guard defensive. Stand down and review the playbook before trading.",
+            )
+        )
+        status = _GUARD_OK
+        message_kwargs: Dict[str, Any]
+        if rule_type == "position_size":
+            minimum = int(rule.get("min_contracts", 1))
+            status = _GUARD_OK if suggested_contracts >= minimum else _GUARD_DEFENSIVE
+            message_kwargs = {"suggested": suggested_contracts, "required": minimum}
+        elif rule_type == "max_daily_loss":
+            policy_cap = float(rule.get("max_loss", profile.max_daily_loss))
+            status = (
+                _GUARD_OK if profile.max_daily_loss <= policy_cap else _GUARD_DEFENSIVE
+            )
+            message_kwargs = {
+                "configured": profile.max_daily_loss,
+                "policy": policy_cap,
+            }
+        elif rule_type == "cooldown":
+            ceiling = int(rule.get("max_losses", profile.cooldown_losses))
+            status = (
+                _GUARD_OK if profile.cooldown_losses <= ceiling else _GUARD_DEFENSIVE
+            )
+            message_kwargs = {
+                "configured": profile.cooldown_losses,
+                "policy": ceiling,
+            }
+        else:  # pragma: no cover - reserved for future policy types
+            raise ValueError(f"Unsupported guard rule type: {rule_type}")
+        template = ok_template if status == _GUARD_OK else defensive_template
+        return GuardRuleResult(
+            rule_id=rule_id,
+            title=title,
+            status=status,
+            message=_safe_format(template, **message_kwargs),
+        )
+
+
+def _safe_format(template: str, **values: Any) -> str:
+    """Format *template* while swallowing placeholder errors."""
+
+    try:
+        return template.format(**values)
+    except (KeyError, ValueError):  # pragma: no cover - defensive fallback
+        return template
+
+
+def _coerce_float(value: Any, fallback: float) -> float:
+    """Best-effort conversion of *value* to ``float`` with a fallback."""
+
+    if value is None:
+        return fallback
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Inspect the Toptek guard policy and evaluation output.",
+    )
+    parser.add_argument(
+        "--policy",
+        type=Path,
+        default=None,
+        help="Optional path to a custom guard policy YAML.",
+    )
+    parser.add_argument(
+        "--dryrun",
+        action="store_true",
+        help="Run the evaluation with policy defaults and print the report.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry-point for ``python -m toptek.risk.engine``."""
+
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    engine = RiskEngine.from_policy(args.policy)
+    profile = engine.build_profile()
+    report = engine.evaluate(profile)
+    if args.dryrun:
+        print(engine.render_report(report))
+        return 0
+    # Default behaviour mirrors --dryrun to keep the CLI informative.
+    print(engine.render_report(report))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI module guard
+    raise SystemExit(main())

--- a/toptek/risk/policy.yml
+++ b/toptek/risk/policy.yml
@@ -1,0 +1,33 @@
+name: Topstep Guard Reference
+version: 2024.09
+defaults:
+  account_balance: 50000
+  atr: 3.5
+  tick_value: 12.5
+  risk_per_trade: 0.01
+profile:
+  max_position_size: 3
+  max_daily_loss: 1500
+  restricted_hours: []
+  atr_multiplier_stop: 2.0
+  cooldown_losses: 2
+  cooldown_minutes: 30
+rules:
+  - id: position-sizing
+    title: Position sizing margin
+    type: position_size
+    min_contracts: 1
+    ok: "Sizing margin supports {suggested} contracts (policy requires ≥{required})."
+    defensive: "Position sizing collapsed to {suggested} contracts; guard requires ≥{required}."
+  - id: loss-cap
+    title: Daily loss cap
+    type: max_daily_loss
+    max_loss: 3000
+    ok: "Daily loss cap ${configured:.0f} sits within the guard ceiling ${policy:.0f}."
+    defensive: "Daily loss cap ${configured:.0f} breaches the guard ceiling ${policy:.0f}."
+  - id: cooldown-discipline
+    title: Cooldown discipline
+    type: cooldown
+    max_losses: 3
+    ok: "Cooldown triggers after {configured} losses (policy ≤{policy})."
+    defensive: "Cooldown waits {configured} losses which is above the policy ceiling ≤{policy}."


### PR DESCRIPTION
## Summary
- add a reusable `toptek.risk` package with a policy file, engine, and CLI dry-run entrypoint for guard evaluation
- enhance the Trade tab with a styled guard badge, live-mode confirmation, and a Ctrl+P panic circuit that flips back to paper trading
- extend documentation and GUI/unit tests to cover guard badge transitions, panic behaviour, and guard policy state updates

## Testing
- `ruff check --fix`
- `black tests/gui/test_trade_tab.py tests/test_replay_cli.py tests/test_risk_engine.py toptek/gui/app.py toptek/gui/widgets.py toptek/risk/engine.py`
- `mypy --config-file mypy.ini`
- `bandit -r toptek -ll` *(fails: command not found)*
- `pytest` *(fails: missing pandas/numpy/sklearn dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e0cf5bcfac8329900e93aa84814a59