### PR TITLE
Add monitoring helpers for drift and latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,18 @@ GUI. Install [`PyYAML`](https://pyyaml.org/) if the command reports a missing
 dependency. The same report is serialised back into the `configs["trade"]`
 dictionary whenever the guard is refreshed, allowing downstream automation to
 respond when the status shifts between `OK` and `DEFENSIVE_MODE`.
+
+## Monitoring surface
+
+Operational dashboards can now import helpers from `toptek.monitor` to surface
+data quality and feed health at a glance:
+
+- `toptek.monitor.compute_drift_report` evaluates PSI/KS drift across a
+  DataFrame slice, returning feature-level and aggregate severities that the UI
+  can render as badges or alerts.
+- `toptek.monitor.build_latency_badge` converts a timestamp for the latest bar
+  into deterministic status copy (`Live`, `Lagging`, `Stalled`) based on latency
+  thresholds.
+
+Both utilities return frozen dataclasses to keep the API predictable for
+widgets, scripts, or automated monitors.

--- a/tests/test_drift_flags.py
+++ b/tests/test_drift_flags.py
@@ -1,0 +1,63 @@
+"""Deterministic checks for the drift severity report."""
+
+from __future__ import annotations
+
+import pytest
+
+from toptek.monitor import Severity, compute_drift_report
+
+
+def _build_column(zero_count: int, one_count: int) -> dict[str, list[int]]:
+    return {"feature": [0] * zero_count + [1] * one_count}
+
+
+def test_compute_drift_report_stable_flag():
+    reference = _build_column(50, 50)
+    current = _build_column(50, 50)
+
+    report = compute_drift_report(reference, current, bins=2)
+
+    assert report.overall == Severity.STABLE
+    feature_report = report.features["feature"]
+    assert feature_report.metric.psi == pytest.approx(0.0)
+    assert feature_report.metric.ks == pytest.approx(0.0)
+    assert feature_report.severity == Severity.STABLE
+    assert feature_report.message == "No material drift detected."
+
+
+def test_compute_drift_report_watch_flag():
+    reference = _build_column(50, 50)
+    current = _build_column(68, 32)
+
+    report = compute_drift_report(reference, current, bins=2)
+
+    feature_report = report.features["feature"]
+    assert feature_report.psi_severity == Severity.WATCH
+    assert feature_report.ks_severity == Severity.WATCH
+    assert feature_report.severity == Severity.WATCH
+    assert report.overall == Severity.WATCH
+
+
+def test_compute_drift_report_alert_flag():
+    reference = _build_column(50, 50)
+    current = _build_column(80, 20)
+
+    report = compute_drift_report(reference, current, bins=2)
+
+    feature_report = report.features["feature"]
+    assert feature_report.severity == Severity.ALERT
+    assert feature_report.metric.psi > 0.25
+    assert feature_report.metric.ks > 0.2
+    assert "alert" in report.summary
+
+
+def test_compute_drift_report_unknown_when_empty():
+    reference = _build_column(50, 50)
+    current = {"feature": []}
+
+    report = compute_drift_report(reference, current)
+
+    feature_report = report.features["feature"]
+    assert feature_report.severity == Severity.UNKNOWN
+    assert report.overall == Severity.UNKNOWN
+    assert report.summary == "One or more features lacked data for drift assessment."

--- a/tests/test_latency_badge.py
+++ b/tests/test_latency_badge.py
@@ -1,0 +1,73 @@
+"""Latency badge tests covering severity transitions."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from toptek.monitor import LatencyBadge, Severity, build_latency_badge
+
+
+def _now() -> datetime:
+    return datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+
+def test_latency_badge_live_severity():
+    badge = build_latency_badge(
+        _now() - timedelta(seconds=10),
+        now=_now(),
+        warning_threshold=30,
+        alert_threshold=90,
+    )
+
+    assert isinstance(badge, LatencyBadge)
+    assert badge.severity == Severity.STABLE
+    assert badge.label == "Live"
+    assert "healthy" in badge.message
+
+
+def test_latency_badge_watch_severity():
+    badge = build_latency_badge(
+        _now() - timedelta(seconds=45),
+        now=_now(),
+        warning_threshold=30,
+        alert_threshold=90,
+    )
+
+    assert badge.severity == Severity.WATCH
+    assert badge.label == "Lagging"
+    assert badge.latency_seconds == pytest.approx(45.0)
+
+
+def test_latency_badge_alert_severity():
+    badge = build_latency_badge(
+        _now() - timedelta(seconds=120),
+        now=_now(),
+        warning_threshold=30,
+        alert_threshold=90,
+    )
+
+    assert badge.severity == Severity.ALERT
+    assert badge.label == "Stalled"
+    assert "stalled" in badge.message.lower()
+
+
+def test_latency_badge_unknown_without_timestamp():
+    badge = build_latency_badge(None, now=_now())
+
+    assert badge.severity == Severity.UNKNOWN
+    assert badge.label == "No signal"
+    assert badge.message == "No bars received yet."
+
+
+def test_latency_badge_validates_threshold_order():
+    with pytest.raises(ValueError):
+        build_latency_badge(
+            _now(), now=_now(), warning_threshold=90, alert_threshold=30
+        )
+
+    with pytest.raises(ValueError):
+        build_latency_badge(
+            _now(), now=_now(), warning_threshold=-1, alert_threshold=30
+        )

--- a/toptek/README.md
+++ b/toptek/README.md
@@ -54,6 +54,9 @@ toptek/
     risk.py
     live.py
     utils.py
+  monitor/
+    drift.py
+    latency.py
   gui/
     app.py
     widgets.py
@@ -69,6 +72,18 @@ Configuration defaults live under the `config/` folder and are merged with value
 - `requirements-streaming.txt`: extends the lite profile with optional SignalR streaming support.
 - On start-up `python -m toptek.main` validates that NumPy/SciPy/scikit-learn match the vetted wheels and raises a friendly
   guidance error if the environment drifts. Reinstall with `pip install -r requirements-lite.txt` to resolve mismatches.
+
+## Monitoring helpers
+
+Use the `toptek.monitor` package to keep an eye on data quality and feed
+freshness:
+
+- `compute_drift_report` compares PSI/KS statistics between reference and
+  current windows, returning severity tiers per feature and overall so the GUI
+  can escalate drift badges deterministically.
+- `build_latency_badge` maps the latest bar timestamp to friendly status copy
+  (`Live`, `Lagging`, `Stalled`) based on configurable thresholds, making it
+  trivial to render latency pills in the dashboard header.
 
 ## Development notes
 

--- a/toptek/monitor/__init__.py
+++ b/toptek/monitor/__init__.py
@@ -1,0 +1,20 @@
+"""Monitoring utilities for drift and latency checks."""
+
+from .drift import (
+    DriftFeatureReport,
+    DriftMetric,
+    DriftReport,
+    Severity,
+    compute_drift_report,
+)
+from .latency import LatencyBadge, build_latency_badge
+
+__all__ = [
+    "DriftFeatureReport",
+    "DriftMetric",
+    "DriftReport",
+    "Severity",
+    "compute_drift_report",
+    "LatencyBadge",
+    "build_latency_badge",
+]

--- a/toptek/monitor/drift.py
+++ b/toptek/monitor/drift.py
@@ -1,0 +1,388 @@
+"""Data drift diagnostics with PSI and KS severity scoring."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+import math
+from collections.abc import Iterable, Mapping, MutableMapping
+from typing import TYPE_CHECKING, List, Optional, Sequence, TypeAlias, cast
+
+try:  # pragma: no cover - optional pandas dependency
+    import pandas as pd  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional pandas dependency
+    pd = None  # type: ignore
+
+if TYPE_CHECKING:  # pragma: no cover
+    from pandas import DataFrame as _PandasDataFrame
+else:  # pragma: no cover
+    _PandasDataFrame = object  # type: ignore[misc, assignment]
+
+ColumnarLike: TypeAlias = Mapping[str, Iterable[object]] | _PandasDataFrame
+
+
+_EPSILON = 1e-9
+
+
+class Severity(IntEnum):
+    """Severity tiers for drift and latency monitors."""
+
+    STABLE = 0
+    WATCH = 1
+    ALERT = 2
+    UNKNOWN = 3
+
+    @property
+    def label(self) -> str:
+        labels = {
+            Severity.STABLE: "stable",
+            Severity.WATCH: "watch",
+            Severity.ALERT: "alert",
+            Severity.UNKNOWN: "unknown",
+        }
+        return labels[self]
+
+    def describe(self) -> str:
+        descriptions = {
+            Severity.STABLE: "Distributions align with reference expectations.",
+            Severity.WATCH: "Shifts detected; monitor the feature closely.",
+            Severity.ALERT: "Large drift; retraining or investigation required.",
+            Severity.UNKNOWN: "Insufficient data to evaluate drift.",
+        }
+        return descriptions[self]
+
+
+@dataclass(frozen=True)
+class DriftMetric:
+    """Container for drift statistics."""
+
+    psi: float
+    ks: float
+
+
+@dataclass(frozen=True)
+class DriftFeatureReport:
+    """Feature-level drift findings."""
+
+    feature: str
+    metric: DriftMetric
+    psi_severity: Severity
+    ks_severity: Severity
+    severity: Severity
+    message: str
+
+
+@dataclass(frozen=True)
+class DriftReport:
+    """Aggregate drift report for a dataset."""
+
+    features: Mapping[str, DriftFeatureReport]
+    overall: Severity
+    summary: str
+
+
+class _Thresholds:
+    """Severity thresholds for PSI and KS."""
+
+    PSI = (0.1, 0.25)
+    KS = (0.1, 0.2)
+
+
+def compute_drift_report(
+    reference: ColumnarLike,
+    current: ColumnarLike,
+    *,
+    features: Optional[Sequence[str]] = None,
+    bins: int = 10,
+) -> DriftReport:
+    """Compute PSI/KS drift metrics and severity tiers.
+
+    Parameters
+    ----------
+    reference:
+        Historical data establishing the baseline distribution.
+    current:
+        Recent data to compare against the baseline.
+    features:
+        Optional subset of columns to analyse. When omitted, the intersection of
+        columns present in both datasets is used.
+    bins:
+        Number of quantile bins used when estimating the PSI.
+
+    Returns
+    -------
+    DriftReport
+        Structured report including per-feature and aggregate severities.
+    """
+
+    if bins < 2:
+        raise ValueError("`bins` must be >= 2 to compute PSI.")
+
+    reference_columns = _column_names(reference)
+    current_columns = _column_names(current)
+
+    if features is None:
+        features = sorted(set(reference_columns).intersection(current_columns))
+    else:
+        missing = [
+            col
+            for col in features
+            if col not in reference_columns or col not in current_columns
+        ]
+        if missing:
+            raise KeyError(
+                f"Requested features not available in both datasets: {missing}"
+            )
+
+    if not features:
+        raise ValueError("No overlapping features to compute drift.")
+
+    per_feature: MutableMapping[str, DriftFeatureReport] = {}
+    alerts: List[str] = []
+    unknown_features: List[str] = []
+
+    for feature in features:
+        ref_values = _extract_numeric(reference, feature)
+        cur_values = _extract_numeric(current, feature)
+
+        if not ref_values or not cur_values:
+            report = DriftFeatureReport(
+                feature=feature,
+                metric=DriftMetric(float("nan"), float("nan")),
+                psi_severity=Severity.UNKNOWN,
+                ks_severity=Severity.UNKNOWN,
+                severity=Severity.UNKNOWN,
+                message="Insufficient data points to compute drift.",
+            )
+            per_feature[feature] = report
+            unknown_features.append(feature)
+            continue
+
+        psi_value = _population_stability_index(ref_values, cur_values, bins=bins)
+        ks_value = _kolmogorov_smirnov(ref_values, cur_values)
+
+        psi_severity = _severity_from_value(psi_value, _Thresholds.PSI)
+        ks_severity = _severity_from_value(ks_value, _Thresholds.KS)
+        severity = max(psi_severity, ks_severity, key=lambda s: s.value)
+
+        if severity == Severity.STABLE:
+            message = "No material drift detected."
+        elif severity == Severity.WATCH:
+            message = "Moderate drift detected; monitor the feature."
+        else:
+            message = "Severe drift detected; investigate immediately."
+
+        report = DriftFeatureReport(
+            feature=feature,
+            metric=DriftMetric(float(psi_value), float(ks_value)),
+            psi_severity=psi_severity,
+            ks_severity=ks_severity,
+            severity=severity,
+            message=message,
+        )
+
+        per_feature[feature] = report
+
+        if severity in (Severity.WATCH, Severity.ALERT):
+            alerts.append(f"{feature}: {severity.label}")
+
+    non_unknown = [
+        feature_report.severity
+        for feature_report in per_feature.values()
+        if feature_report.severity != Severity.UNKNOWN
+    ]
+
+    overall: Severity
+    if non_unknown:
+        overall = max(non_unknown, key=lambda s: s.value)
+    else:
+        overall = Severity.UNKNOWN
+
+    if overall == Severity.STABLE:
+        summary = "All monitored features remain stable."
+        if unknown_features:
+            summary += f" ({', '.join(unknown_features)} missing data)"
+    elif overall == Severity.UNKNOWN:
+        summary = "One or more features lacked data for drift assessment."
+    else:
+        summary = "; ".join(alerts)
+        if unknown_features:
+            summary += f"; {', '.join(unknown_features)} missing data"
+
+    return DriftReport(features=dict(per_feature), overall=overall, summary=summary)
+
+
+def _column_names(data: ColumnarLike) -> List[str]:
+    if pd is not None and isinstance(data, pd.DataFrame):  # type: ignore[arg-type]
+        return [str(column) for column in data.columns]
+    if isinstance(data, Mapping):
+        mapping_data = cast(Mapping[str, Iterable[object]], data)
+        return [str(column) for column in mapping_data.keys()]
+    raise TypeError("Unsupported container type for drift computation.")
+
+
+def _extract_numeric(data: ColumnarLike, feature: str) -> List[float]:
+    if pd is not None and isinstance(data, pd.DataFrame):  # type: ignore[arg-type]
+        series = pd.to_numeric(data[feature], errors="coerce").dropna()
+        return [float(value) for value in series.tolist()]
+    if isinstance(data, Mapping):
+        mapping_data = cast(Mapping[str, Iterable[object]], data)
+        if feature not in mapping_data:
+            raise KeyError(f"Column '{feature}' not present in dataset.")
+        column = mapping_data[feature]
+    else:
+        raise TypeError("Unsupported container type for drift computation.")
+
+    return _coerce_to_list(column)
+
+
+def _coerce_to_list(values: Iterable[object]) -> List[float]:
+    cleaned: List[float] = []
+    for value in values:
+        try:
+            number = float(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            continue
+        if not math.isfinite(number):
+            continue
+        cleaned.append(number)
+
+    return cleaned
+
+
+def _population_stability_index(
+    reference: List[float], current: List[float], *, bins: int
+) -> float:
+    """Population Stability Index with quantile binning."""
+
+    if not reference or not current:
+        return float("nan")
+
+    reference_sorted = sorted(reference)
+    current_sorted = sorted(current)
+
+    quantiles = [index / bins for index in range(bins + 1)]
+    edges = [_quantile(reference_sorted, q) for q in quantiles]
+    edges = _unique_sorted(edges)
+
+    if len(edges) == 1:
+        midpoint = edges[0]
+        spread = max(
+            max((abs(value - midpoint) for value in reference_sorted), default=0.0),
+            max((abs(value - midpoint) for value in current_sorted), default=0.0),
+        )
+        if spread == 0:
+            return 0.0
+        edges = [midpoint - spread, midpoint + spread]
+
+    low_bound = min(min(reference_sorted), min(current_sorted)) - _EPSILON
+    high_bound = max(max(reference_sorted), max(current_sorted)) + _EPSILON
+    edges[0] = min(edges[0], low_bound)
+    edges[-1] = max(edges[-1], high_bound)
+
+    ref_hist = _histogram(reference_sorted, edges)
+    cur_hist = _histogram(current_sorted, edges)
+
+    ref_total = sum(ref_hist)
+    cur_total = sum(cur_hist)
+
+    if ref_total == 0 or cur_total == 0:
+        return float("nan")
+
+    psi = 0.0
+    for ref_count, cur_count in zip(ref_hist, cur_hist):
+        ref_ratio = max(ref_count / ref_total, _EPSILON)
+        cur_ratio = max(cur_count / cur_total, _EPSILON)
+        psi += (cur_ratio - ref_ratio) * math.log(cur_ratio / ref_ratio)
+
+    return psi
+
+
+def _kolmogorov_smirnov(reference: List[float], current: List[float]) -> float:
+    """Two-sample Kolmogorov-Smirnov statistic."""
+
+    if not reference or not current:
+        return float("nan")
+
+    reference_sorted = sorted(reference)
+    current_sorted = sorted(current)
+
+    n_ref = len(reference_sorted)
+    n_cur = len(current_sorted)
+    ref_index = 0
+    cur_index = 0
+    max_diff = 0.0
+
+    for value in _unique_sorted(reference_sorted + current_sorted):
+        while ref_index < n_ref and reference_sorted[ref_index] <= value:
+            ref_index += 1
+        while cur_index < n_cur and current_sorted[cur_index] <= value:
+            cur_index += 1
+        ref_cdf = ref_index / n_ref
+        cur_cdf = cur_index / n_cur
+        diff = abs(ref_cdf - cur_cdf)
+        if diff > max_diff:
+            max_diff = diff
+
+    return max_diff
+
+
+def _quantile(sorted_values: List[float], quantile: float) -> float:
+    if not sorted_values:
+        raise ValueError("Cannot compute quantile of empty data.")
+    if quantile <= 0:
+        return sorted_values[0]
+    if quantile >= 1:
+        return sorted_values[-1]
+
+    position = quantile * (len(sorted_values) - 1)
+    lower_index = math.floor(position)
+    upper_index = math.ceil(position)
+
+    if lower_index == upper_index:
+        return sorted_values[int(position)]
+
+    lower_value = sorted_values[lower_index]
+    upper_value = sorted_values[upper_index]
+    weight = position - lower_index
+    return lower_value + (upper_value - lower_value) * weight
+
+
+def _histogram(values: List[float], edges: List[float]) -> List[int]:
+    counts = [0 for _ in range(len(edges) - 1)]
+    for value in values:
+        for index in range(len(counts)):
+            left = edges[index]
+            right = edges[index + 1]
+            if index == len(counts) - 1:
+                if left <= value <= right:
+                    counts[index] += 1
+                    break
+            elif left <= value < right:
+                counts[index] += 1
+                break
+    return counts
+
+
+def _unique_sorted(values: Iterable[float]) -> List[float]:
+    unique: List[float] = []
+    for value in sorted(values):
+        if not unique or not math.isclose(
+            value, unique[-1], rel_tol=0.0, abs_tol=_EPSILON
+        ):
+            unique.append(value)
+    return unique
+
+
+def _severity_from_value(value: float, thresholds: Sequence[float]) -> Severity:
+    """Map a metric value to a severity tier."""
+
+    if value is None or math.isnan(value):
+        return Severity.UNKNOWN
+
+    low, high = thresholds
+    if value < low:
+        return Severity.STABLE
+    if value < high:
+        return Severity.WATCH
+    return Severity.ALERT

--- a/toptek/monitor/latency.py
+++ b/toptek/monitor/latency.py
@@ -1,0 +1,93 @@
+"""Latency utilities for rendering last-bar freshness badges."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+from .drift import Severity
+
+
+@dataclass(frozen=True)
+class LatencyBadge:
+    """Badge metadata describing feed latency for UI surfaces."""
+
+    severity: Severity
+    latency_seconds: float
+    label: str
+    message: str
+
+
+def build_latency_badge(
+    last_bar_timestamp: Optional[datetime],
+    *,
+    now: Optional[datetime] = None,
+    warning_threshold: float = 30.0,
+    alert_threshold: float = 90.0,
+) -> LatencyBadge:
+    """Compute a latency badge for the latest market bar.
+
+    Parameters
+    ----------
+    last_bar_timestamp:
+        Timestamp of the last ingested bar. When ``None`` the badge will fall
+        back to ``UNKNOWN`` severity.
+    now:
+        Optional override for the current timestamp. Defaults to
+        ``datetime.now(timezone.utc)`` to keep the computation deterministic
+        during testing.
+    warning_threshold:
+        Boundary in seconds where the badge escalates to ``WATCH`` severity.
+    alert_threshold:
+        Boundary in seconds where the badge escalates to ``ALERT`` severity.
+
+    Returns
+    -------
+    LatencyBadge
+        Structured badge metadata with severity and copy for the UI layer.
+    """
+
+    if warning_threshold <= 0 or alert_threshold <= 0:
+        raise ValueError("Thresholds must be positive numbers.")
+    if alert_threshold <= warning_threshold:
+        raise ValueError("`alert_threshold` must exceed `warning_threshold`.")
+
+    if now is None:
+        now = datetime.now(timezone.utc)
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+
+    if last_bar_timestamp is None:
+        return LatencyBadge(
+            severity=Severity.UNKNOWN,
+            latency_seconds=float("nan"),
+            label="No signal",
+            message="No bars received yet.",
+        )
+
+    if last_bar_timestamp.tzinfo is None:
+        last_bar_timestamp = last_bar_timestamp.replace(tzinfo=timezone.utc)
+
+    latency_seconds = (now - last_bar_timestamp).total_seconds()
+    latency_seconds = max(latency_seconds, 0.0)
+
+    if latency_seconds < warning_threshold:
+        severity = Severity.STABLE
+        label = "Live"
+        message = f"Feed healthy ({latency_seconds:.0f}s latency)."
+    elif latency_seconds < alert_threshold:
+        severity = Severity.WATCH
+        label = "Lagging"
+        message = f"Feed delayed ({latency_seconds:.0f}s latency)."
+    else:
+        severity = Severity.ALERT
+        label = "Stalled"
+        message = f"Feed stalled ({latency_seconds:.0f}s latency)."
+
+    return LatencyBadge(
+        severity=severity,
+        latency_seconds=latency_seconds,
+        label=label,
+        message=message,
+    )


### PR DESCRIPTION
## Summary
- add a `toptek.monitor` package that reports per-feature and aggregate PSI/KS drift severities without relying on heavy dependencies
- expose a latency badge helper that classifies last-bar freshness into stable/watch/alert tiers for UI badges
- document the monitoring surface and add deterministic tests that exercise severity thresholds and badge messaging

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e13e02d3e483299d89c6c425ef6da2