### PR TITLE
Fix LiveTab utils import

### DIFF
--- a/toptek/gui/live_tab.py
+++ b/toptek/gui/live_tab.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict, Iterable, List
 import tkinter as tk
 from tkinter import ttk
 
-from core.utils import json_dumps
+from toptek.core import utils
 
 from . import TEXT_WIDGET_DEFAULTS
 
@@ -204,7 +204,7 @@ class LiveTab(ttk.Frame):
         metrics["last_refresh"] = datetime.now(tz=timezone.utc).isoformat()
         self.metrics_state.update(metrics)
         self.metrics_output.delete("1.0", tk.END)
-        self.metrics_output.insert("1.0", json_dumps(metrics, indent=2))
+        self.metrics_output.insert("1.0", utils.json_dumps(metrics, indent=2))
         self.metrics_output.see("1.0")
         self.configs.setdefault("live", {})["metrics"] = dict(self.metrics_state)
         return metrics


### PR DESCRIPTION
## Summary
- update the Live tab to import the json helpers via `toptek.core.utils`
- adjust the metrics rendering call to reference `utils.json_dumps`

## Testing
- pytest tests/gui/test_live_tab_wiring.py

------
https://chatgpt.com/codex/tasks/task_e_68e197e2dfbc8329a4045118ef6f4202