### PR TITLE
Preserve LiveTab chat log state

### DIFF
--- a/tests/gui/test_ui_live_tab_state.py
+++ b/tests/gui/test_ui_live_tab_state.py
@@ -1,0 +1,36 @@
+"""Tk-aware smoke tests for the UI LiveTab widget."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+tk = pytest.importorskip("tkinter")
+from tkinter import ttk  # noqa: E402
+
+from toptek.ui.live_tab import LiveTab  # noqa: E402
+
+
+@pytest.fixture
+def tk_root() -> Any:
+    try:
+        root = tk.Tk()
+    except tk.TclError as exc:  # pragma: no cover - depends on CI
+        pytest.skip(f"Tk unavailable: {exc}")
+    root.withdraw()
+    yield root
+    root.destroy()
+
+
+def test_live_tab_chat_log_disabled_initially(tk_root: Any) -> None:
+    notebook = ttk.Notebook(tk_root)
+    notebook.pack()
+
+    class DummyClient:
+        def chat(self, messages):  # pragma: no cover - not used in test
+            raise AssertionError("chat should not be called")
+
+    tab = LiveTab(notebook, {"model": "test-model"}, client=DummyClient())
+
+    assert tab.chat_log["state"] == "disabled"

--- a/toptek/ui/live_tab.py
+++ b/toptek/ui/live_tab.py
@@ -75,6 +75,7 @@ class LiveTab(_BaseFrame):
         chat_frame = ttk.LabelFrame(self, text="Conversation")
         chat_frame.pack(fill=tk.BOTH, expand=True, padx=16, pady=(0, 12))
         self._style_text_widget(self.chat_log)
+        self.chat_log.configure(state="disabled")
         self.chat_log.pack(in_=chat_frame, fill=tk.BOTH, expand=True, padx=8, pady=8)
 
         input_frame = ttk.Frame(self, style="DashboardBackground.TFrame")
@@ -101,8 +102,11 @@ class LiveTab(_BaseFrame):
             self.system_prompt_text.insert("1.0", prompt)
 
     def _style_text_widget(self, widget: tk.Text) -> None:
+        original_state = widget.cget("state")
+        if original_state == "disabled":
+            widget.configure(state="normal")
         widget.configure(**TEXT_WIDGET_DEFAULTS)
-        widget.configure(state="normal")
+        widget.configure(state=original_state)
 
     def _handle_enter(self, event: tk.Event) -> None:
         self.send_message()


### PR DESCRIPTION
## Summary
- keep LiveTab text widget styling from forcing the chat log into an editable state
- explicitly re-disable the chat log during layout and cover the regression with a Tk-aware test

## Testing
- TOPTEK_SKIP_TRACE_COVERAGE=1 pytest tests/gui/test_ui_live_tab_state.py

------
https://chatgpt.com/codex/tasks/task_e_68e1ad710e3c83299360d60a89ed1ce7