### PR TITLE
Add streaming inference loop and signal metrics

### DIFF
--- a/tests/test_infer_service.py
+++ b/tests/test_infer_service.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+import sqlite3
+import pickle
+
+np = pytest.importorskip("numpy")
+pd = pytest.importorskip("pandas")
+
+from toptek.data import BarRecord, SQLiteBarFeed, run_migrations
+from toptek.loops.infer import InferConfig, PredictionService
+from toptek.model.metrics import MetricsAPI
+
+
+class _StubCalibrator:
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:
+        logits = np.tanh(X[:, 0] / 500.0)
+        prob_up = 0.5 + 0.5 * logits
+        prob_up = np.clip(prob_up, 0.01, 0.99)
+        return np.column_stack([1.0 - prob_up, prob_up])
+
+
+def _generate_bars(symbol: str, count: int) -> list[BarRecord]:
+    start = datetime(2024, 1, 1, 9, 30)
+    records: list[BarRecord] = []
+    price = 4800.0
+    for idx in range(count):
+        ts = start + timedelta(minutes=5 * idx)
+        drift = 0.5 + 0.05 * np.sin(idx / 3)
+        close = price + drift
+        records.append(
+            BarRecord(
+                symbol=symbol,
+                ts=ts,
+                open=price,
+                high=price + 1.5,
+                low=price - 1.5,
+                close=close,
+                volume=1200 + idx,
+            )
+        )
+        price = close
+    return records
+
+
+def test_prediction_service_updates_metrics(tmp_path: Path) -> None:
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+
+    calibrator = _StubCalibrator()
+    with (models_dir / "calibrator.pkl").open("wb") as handle:
+        pickle.dump(calibrator, handle)
+    card = {
+        "feature_names": [
+            "sma_10",
+            "sma_20",
+            "ema_12",
+            "ema_26",
+            "rsi_14",
+        ],
+        "features_hash": "integration",
+        "versions": {"model": "stub-v1"},
+    }
+    (models_dir / "model_card.json").write_text(json.dumps(card), encoding="utf-8")
+
+    conn = sqlite3.connect(tmp_path / "predictions.db")
+    conn.row_factory = sqlite3.Row
+    run_migrations(conn)
+
+    feed = SQLiteBarFeed(conn)
+    symbol = "ESZ25"
+    all_records = _generate_bars(symbol, 48)
+    feed.insert(all_records[:32])
+
+    config = InferConfig(models_dir=models_dir, symbols=(symbol,), decision_threshold=0.55, max_history=256)
+    service = PredictionService(config, conn=conn)
+
+    first_pass = service.run_once()
+    assert symbol in first_pass and first_pass[symbol]
+
+    predictions = pd.read_sql_query(
+        "SELECT * FROM model_predictions WHERE symbol = ? ORDER BY ts", conn, params=(symbol,)
+    )
+    assert not predictions.empty
+    unresolved_before = predictions["realized_ts"].isna().sum()
+    assert unresolved_before >= 1
+
+    metrics_api = MetricsAPI(conn, window=64)
+    snapshot_before = metrics_api.payload([symbol])[symbol]
+    assert snapshot_before["observations"] >= 1
+    assert snapshot_before["hit_rate"] >= 0.0
+
+    feed.insert(all_records[32:])
+    second_pass = service.run_once()
+    assert symbol in second_pass and second_pass[symbol]
+
+    predictions_after = pd.read_sql_query(
+        "SELECT * FROM model_predictions WHERE symbol = ? ORDER BY ts", conn, params=(symbol,)
+    )
+    assert len(predictions_after) > len(predictions)
+    resolved = predictions_after[predictions_after["realized_ts"].notna()]
+    assert len(resolved) >= len(predictions_after) - 1
+
+    snapshot_after = metrics_api.payload([symbol])[symbol]
+    assert snapshot_after["observations"] >= snapshot_before["observations"]
+    assert snapshot_after["confidence"] == pytest.approx(
+        float(predictions_after["prob_up"].iloc[-1])
+    )
+    assert snapshot_after["hit_rate"] >= 0.0
+
+    service.close()
+    conn.close()

--- a/toptek/data/__init__.py
+++ b/toptek/data/__init__.py
@@ -1,5 +1,6 @@
 """Data access package exposing IO utilities."""
 
+from .feeds import BarRecord, SQLiteBarFeed
 from .io import (
     DATA_DIR,
     VAR_DIR,
@@ -18,4 +19,6 @@ __all__ = [
     "export_to_parquet",
     "load_demo_data",
     "run_migrations",
+    "BarRecord",
+    "SQLiteBarFeed",
 ]

--- a/toptek/data/feeds.py
+++ b/toptek/data/feeds.py
@@ -1,0 +1,125 @@
+"""Streaming helpers for querying fresh market bars from SQLite."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, Iterator, List, Sequence
+
+import pandas as pd
+import sqlite3
+
+_BAR_COLUMNS = ["open", "high", "low", "close", "volume"]
+
+
+@dataclass(frozen=True)
+class BarRecord:
+    """Immutable representation of a single OHLCV bar."""
+
+    symbol: str
+    ts: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+    @classmethod
+    def from_row(cls, row: Sequence[object]) -> "BarRecord":
+        return cls(
+            symbol=str(row[0]),
+            ts=datetime.fromisoformat(str(row[1])),
+            open=float(row[2]),
+            high=float(row[3]),
+            low=float(row[4]),
+            close=float(row[5]),
+            volume=float(row[6]),
+        )
+
+
+class SQLiteBarFeed:
+    """Utility for streaming incremental bars from the SQLite data layer."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    def insert(self, records: Iterable[BarRecord]) -> int:
+        payload = [
+            (
+                record.symbol,
+                record.ts.isoformat(),
+                float(record.open),
+                float(record.high),
+                float(record.low),
+                float(record.close),
+                float(record.volume),
+            )
+            for record in records
+        ]
+        if not payload:
+            return 0
+        self._conn.executemany(
+            (
+                "INSERT OR REPLACE INTO market_bars(symbol, ts, open, high, low, close, volume) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)"
+            ),
+            payload,
+        )
+        self._conn.commit()
+        return len(payload)
+
+    def fetch(
+        self,
+        symbol: str,
+        *,
+        since: datetime | None = None,
+        limit: int | None = None,
+    ) -> pd.DataFrame:
+        """Fetch bars newer than ``since`` ordered by timestamp."""
+
+        conditions: List[str] = ["symbol = ?"]
+        params: List[object] = [symbol]
+        if since is not None:
+            conditions.append("ts > ?")
+            params.append(since.isoformat())
+        where = " AND ".join(conditions)
+        query = (
+            "SELECT symbol, ts, open, high, low, close, volume "
+            f"FROM market_bars WHERE {where} ORDER BY ts ASC"
+        )
+        if limit is not None:
+            query += " LIMIT ?"
+            params.append(int(limit))
+
+        cursor = self._conn.execute(query, params)
+        rows = cursor.fetchall()
+        if not rows:
+            return pd.DataFrame(columns=["symbol", *_BAR_COLUMNS])
+        records = [BarRecord.from_row(row) for row in rows]
+        frame = pd.DataFrame(
+            {
+                "symbol": [record.symbol for record in records],
+                "open": [record.open for record in records],
+                "high": [record.high for record in records],
+                "low": [record.low for record in records],
+                "close": [record.close for record in records],
+                "volume": [record.volume for record in records],
+            },
+            index=pd.Index([record.ts for record in records], name="ts"),
+        )
+        return frame
+
+    def stream(
+        self,
+        symbol: str,
+        *,
+        since: datetime | None = None,
+    ) -> Iterator[pd.Series]:
+        """Iterate through bars newer than ``since`` one-at-a-time."""
+
+        frame = self.fetch(symbol, since=since)
+        for timestamp, row in frame.iterrows():
+            yield pd.Series(row, name=timestamp)
+
+
+__all__ = ["BarRecord", "SQLiteBarFeed"]

--- a/toptek/loops/infer.py
+++ b/toptek/loops/infer.py
@@ -1,0 +1,260 @@
+"""Real-time inference loop streaming predictions into the data layer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Sequence
+
+import numpy as np
+import pandas as pd
+import yaml
+import pickle
+
+try:  # pragma: no cover - optional dependency
+    import joblib
+except ModuleNotFoundError:  # pragma: no cover - fallback to stdlib pickle
+    joblib = None  # type: ignore[assignment]
+
+from toptek.core import features as core_features
+from toptek.data import SQLiteBarFeed, connect, run_migrations
+
+
+@dataclass(frozen=True)
+class InferConfig:
+    """Configuration for the streaming inference service."""
+
+    models_dir: Path
+    symbols: Sequence[str]
+    decision_threshold: float = 0.5
+    max_history: int = 2048
+
+
+def load_config(path: Path) -> InferConfig:
+    with path.open("r", encoding="utf-8") as handle:
+        raw = yaml.safe_load(handle)
+    base = path.parent
+    models_dir = base / raw["models_dir"] if not Path(raw["models_dir"]).is_absolute() else Path(raw["models_dir"])
+    symbols_raw = raw.get("symbols") or []
+    if isinstance(symbols_raw, str):
+        symbols = (symbols_raw,)
+    else:
+        symbols = tuple(str(symbol).upper() for symbol in symbols_raw if symbol)
+    if not symbols:
+        raise ValueError("At least one symbol must be configured for inference")
+    return InferConfig(
+        models_dir=models_dir.resolve(),
+        symbols=symbols,
+        decision_threshold=float(raw.get("decision_threshold", 0.5)),
+        max_history=int(raw.get("max_history", 2048)),
+    )
+
+
+class PredictionService:
+    """Stream bars, emit calibrated probabilities, and settle outcomes."""
+
+    def __init__(self, config: InferConfig, *, conn=None) -> None:
+        self.config = config
+        self._owns_connection = conn is None
+        self.conn = conn or connect()
+        run_migrations(self.conn)
+        self.feed = SQLiteBarFeed(self.conn)
+        self.calibrator, self.card = self._load_artifacts(config.models_dir)
+        self.feature_names: List[str] = list(self.card.get("feature_names", []))
+        if not self.feature_names:
+            raise ValueError("Model card missing feature names")
+        self.model_version = str(
+            self.card.get("versions", {}).get("model", "unknown")
+        )
+        self.features_hash = str(self.card.get("features_hash", ""))
+        self._bars: Dict[str, pd.DataFrame] = {}
+        self._known_predictions: Dict[str, set[str]] = {
+            symbol: self._load_existing_predictions(symbol) for symbol in config.symbols
+        }
+
+    def _load_artifacts(self, models_dir: Path):
+        calibrator_path = models_dir / "calibrator.pkl"
+        card_path = models_dir / "model_card.json"
+        if not calibrator_path.exists():
+            raise FileNotFoundError(f"Missing calibrator: {calibrator_path}")
+        if not card_path.exists():
+            raise FileNotFoundError(f"Missing model card: {card_path}")
+        calibrator = self._load_pickle(calibrator_path)
+        with card_path.open("r", encoding="utf-8") as handle:
+            card = json.load(handle)
+        return calibrator, card
+
+    @staticmethod
+    def _load_pickle(path: Path):
+        if joblib is not None:
+            return joblib.load(path)
+        with path.open("rb") as handle:
+            return pickle.load(handle)
+
+    def _load_existing_predictions(self, symbol: str) -> set[str]:
+        cursor = self.conn.execute(
+            "SELECT ts FROM model_predictions WHERE symbol = ? ORDER BY ts", (symbol,)
+        )
+        rows = cursor.fetchall()
+        return {str(row[0]) for row in rows if row[0] is not None}
+
+    def close(self) -> None:
+        if self._owns_connection:
+            self.conn.close()
+
+    def run_once(self) -> Dict[str, List[Dict[str, object]]]:
+        """Process the latest bars for all configured symbols."""
+
+        results: Dict[str, List[Dict[str, object]]] = {}
+        changed = False
+        for symbol in self.config.symbols:
+            ingested = self._ingest(symbol)
+            new_predictions = self._predict(symbol) if ingested else []
+            settled = self._settle(symbol)
+            if new_predictions:
+                results[symbol] = new_predictions
+            if ingested or new_predictions or settled:
+                changed = True
+        if changed:
+            self.conn.commit()
+        return results
+
+    def _ingest(self, symbol: str) -> bool:
+        history = self._bars.get(symbol)
+        since = history.index.max() if history is not None and not history.empty else None
+        frame = self.feed.fetch(symbol, since=since)
+        if frame.empty:
+            return False
+        frame = frame.sort_index()
+        frame = frame[~frame.index.duplicated(keep="last")]
+        if history is None or history.empty:
+            updated = frame
+        else:
+            updated = pd.concat([history, frame])
+            updated = updated[~updated.index.duplicated(keep="last")]
+        if len(updated) > self.config.max_history:
+            updated = updated.tail(self.config.max_history)
+        self._bars[symbol] = updated
+        return True
+
+    def _predict(self, symbol: str) -> List[Dict[str, object]]:
+        bars = self._bars.get(symbol)
+        if bars is None or bars.empty:
+            return []
+        features_df = self._build_feature_frame(bars)
+        if features_df.empty:
+            return []
+        known = self._known_predictions.setdefault(symbol, set())
+        candidate_mask = ~features_df.index.astype(str).isin(known)
+        candidates = features_df.loc[candidate_mask]
+        if candidates.empty:
+            return []
+        matrix = candidates[self.feature_names].to_numpy(dtype=np.float64)
+        probabilities = self.calibrator.predict_proba(matrix)[:, 1]
+        inserted: List[Dict[str, object]] = []
+        for ts, prob_up in zip(candidates.index, probabilities):
+            record = self._persist_prediction(symbol, ts, float(prob_up))
+            known.add(ts.isoformat())
+            inserted.append(record)
+        return inserted
+
+    def _persist_prediction(self, symbol: str, ts: pd.Timestamp, prob_up: float) -> Dict[str, object]:
+        prob_down = float(max(0.0, min(1.0, 1.0 - prob_up)))
+        threshold = self.config.decision_threshold
+        chosen = int(prob_up >= threshold)
+        pred_id = f"{symbol}-{ts.isoformat()}"
+        payload = {
+            "pred_id": pred_id,
+            "ts": ts.isoformat(),
+            "symbol": symbol,
+            "prob_up": prob_up,
+            "prob_down": prob_down,
+            "model_ver": self.model_version,
+            "features_hash": self.features_hash,
+            "decision_threshold": threshold,
+            "chosen": chosen,
+            "meta": json.dumps({"source": "infer"}),
+        }
+        self.conn.execute(
+            (
+                "INSERT OR IGNORE INTO model_predictions(" \
+                "pred_id, ts, symbol, prob_up, prob_down, model_ver, features_hash, decision_threshold, chosen, meta) "
+                "VALUES (:pred_id, :ts, :symbol, :prob_up, :prob_down, :model_ver, :features_hash, :decision_threshold, :chosen, :meta)"
+            ),
+            payload,
+        )
+        return payload
+
+    def _build_feature_frame(self, bars: pd.DataFrame) -> pd.DataFrame:
+        feature_map = core_features.compute_features(bars)
+        features_df = pd.DataFrame(feature_map, index=bars.index)
+        features_df.replace([np.inf, -np.inf], np.nan, inplace=True)
+        features_df = features_df[self.feature_names]
+        features_df.dropna(inplace=True)
+        return features_df
+
+    def _settle(self, symbol: str) -> bool:
+        bars = self._bars.get(symbol)
+        if bars is None or len(bars) < 2:
+            return False
+        cursor = self.conn.execute(
+            "SELECT pred_id, ts FROM model_predictions WHERE symbol = ? AND realized_ts IS NULL ORDER BY ts",
+            (symbol,),
+        )
+        rows = cursor.fetchall()
+        if not rows:
+            return False
+        timestamps = bars.index
+        closes = bars["close"].to_numpy(dtype=float)
+        updated = False
+        for pred_id, ts_raw in rows:
+            ts = pd.Timestamp(ts_raw)
+            try:
+                idx = int(timestamps.get_loc(ts))
+            except KeyError:
+                continue
+            if idx >= len(timestamps) - 1:
+                continue
+            current_close = closes[idx]
+            next_close = closes[idx + 1]
+            realized_return = 0.0 if current_close == 0 else (next_close - current_close) / current_close
+            realized_hit = int(next_close > current_close)
+            realized_ts = timestamps[idx + 1]
+            self.conn.execute(
+                (
+                    "UPDATE model_predictions "
+                    "SET realized_hit = ?, realized_return = ?, realized_ts = ? "
+                    "WHERE pred_id = ?"
+                ),
+                (
+                    realized_hit,
+                    realized_return,
+                    realized_ts.isoformat(),
+                    pred_id,
+                ),
+            )
+            updated = True
+        return updated
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Toptek streaming inference service")
+    parser.add_argument("--config", required=True, help="Path to inference YAML config")
+    return parser.parse_args()
+
+
+def main() -> None:  # pragma: no cover - exercised by integration test entry point
+    args = _parse_args()
+    config = load_config(Path(args.config).resolve())
+    service = PredictionService(config)
+    try:
+        while True:
+            produced = service.run_once()
+            if not produced:
+                break
+    finally:
+        service.close()
+
+
+__all__ = ["InferConfig", "PredictionService", "load_config"]

--- a/toptek/model/metrics.py
+++ b/toptek/model/metrics.py
@@ -1,0 +1,109 @@
+"""Rolling performance metrics for live model predictions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, Sequence
+
+import pandas as pd
+import sqlite3
+
+
+@dataclass(frozen=True)
+class ContractMetrics:
+    """Snapshot of rolling metrics for a single contract."""
+
+    symbol: str
+    hit_rate: float
+    expectancy: float
+    observations: int
+    confidence: float
+    entry: float
+    target: float
+    stop: float
+    updated: str
+
+    def as_dict(self) -> Dict[str, float | str]:
+        return {
+            "symbol": self.symbol,
+            "hit_rate": self.hit_rate,
+            "expectancy": self.expectancy,
+            "observations": self.observations,
+            "confidence": self.confidence,
+            "entry": self.entry,
+            "target": self.target,
+            "stop": self.stop,
+            "updated": self.updated,
+        }
+
+
+class RollingMetrics:
+    """Compute rolling hit-rate and expectancy for configured contracts."""
+
+    def __init__(self, conn: sqlite3.Connection, *, window: int = 100) -> None:
+        self._conn = conn
+        self._window = max(1, int(window))
+
+    def snapshot(self, symbols: Sequence[str]) -> Dict[str, ContractMetrics]:
+        return {symbol: self.compute(symbol) for symbol in symbols}
+
+    def compute(self, symbol: str) -> ContractMetrics:
+        predictions = pd.read_sql_query(
+            (
+                "SELECT ts, prob_up, realized_hit, realized_return "
+                "FROM model_predictions WHERE symbol = ? "
+                "ORDER BY ts DESC LIMIT ?"
+            ),
+            self._conn,
+            params=(symbol, self._window),
+        )
+        predictions["ts"] = pd.to_datetime(predictions["ts"], errors="coerce")
+        resolved = predictions.dropna(subset=["realized_hit", "realized_return"])
+        observations = int(len(resolved))
+        hit_rate = float(resolved["realized_hit"].mean()) if observations else 0.0
+        expectancy = float(resolved["realized_return"].mean()) if observations else 0.0
+        confidence = float(predictions["prob_up"].iloc[0]) if not predictions.empty else 0.0
+        updated = (
+            predictions["ts"].iloc[0].isoformat()
+            if not predictions.empty and pd.notna(predictions["ts"].iloc[0])
+            else ""
+        )
+
+        bars = pd.read_sql_query(
+            "SELECT ts, close FROM market_bars WHERE symbol = ? ORDER BY ts DESC LIMIT 1",
+            self._conn,
+            params=(symbol,),
+        )
+        entry = float(bars["close"].iloc[0]) if not bars.empty else 0.0
+        if entry and observations:
+            target = entry * (1.0 + expectancy)
+            stop = entry * (1.0 - abs(expectancy))
+        else:
+            target = entry
+            stop = entry
+
+        return ContractMetrics(
+            symbol=symbol,
+            hit_rate=hit_rate,
+            expectancy=expectancy,
+            observations=observations,
+            confidence=confidence,
+            entry=entry,
+            target=target,
+            stop=stop,
+            updated=updated,
+        )
+
+
+class MetricsAPI:
+    """Facade exposing polling-friendly metrics responses."""
+
+    def __init__(self, conn: sqlite3.Connection, *, window: int = 100) -> None:
+        self._engine = RollingMetrics(conn, window=window)
+
+    def payload(self, symbols: Sequence[str]) -> Dict[str, Mapping[str, float | str]]:
+        snapshots = self._engine.snapshot(symbols)
+        return {symbol: metrics.as_dict() for symbol, metrics in snapshots.items()}
+
+
+__all__ = ["ContractMetrics", "RollingMetrics", "MetricsAPI"]

--- a/toptek/ui/hooks.py
+++ b/toptek/ui/hooks.py
@@ -57,12 +57,15 @@ def record_prediction(**kwargs: Any) -> None:
             "features_hash": kwargs.get("features_hash"),
             "decision_threshold": kwargs.get("decision_threshold"),
             "chosen": kwargs.get("chosen"),
+            "realized_hit": kwargs.get("realized_hit"),
+            "realized_return": kwargs.get("realized_return"),
+            "realized_ts": kwargs.get("realized_ts"),
             "meta": json.dumps(kwargs.get("meta", {})),
         }
         conn.execute(
             (
-                "INSERT OR REPLACE INTO model_predictions(pred_id, ts, symbol, prob_up, prob_down, model_ver, features_hash, decision_threshold, chosen, meta) "
-                "VALUES (:pred_id, :ts, :symbol, :prob_up, :prob_down, :model_ver, :features_hash, :decision_threshold, :chosen, :meta)"
+                "INSERT OR REPLACE INTO model_predictions(pred_id, ts, symbol, prob_up, prob_down, model_ver, features_hash, decision_threshold, chosen, realized_hit, realized_return, realized_ts, meta) "
+                "VALUES (:pred_id, :ts, :symbol, :prob_up, :prob_down, :model_ver, :features_hash, :decision_threshold, :chosen, :realized_hit, :realized_return, :realized_ts, :meta)"
             ),
             payload,
         )

--- a/toptek/ui/live_tab.py
+++ b/toptek/ui/live_tab.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, Mapping, MutableSequence
+from typing import Dict, List, Mapping, MutableSequence, Sequence
 
 try:  # pragma: no cover - exercised via import behaviour
     import tkinter as tk
@@ -12,11 +12,25 @@ except ModuleNotFoundError:  # pragma: no cover - headless environments
     ttk = None  # type: ignore[assignment]
 
 from toptek import filters
+from toptek.data import connect, run_migrations
 from toptek.gui import DARK_PALETTE, TEXT_WIDGET_DEFAULTS
 from toptek.lmstudio import LMStudioClient, build_client
+from toptek.model.metrics import MetricsAPI
 
 
 _BaseFrame = ttk.Frame if ttk is not None else object
+
+
+def _fetch_signal_metrics(symbols: Sequence[str]) -> Dict[str, Mapping[str, object]]:
+    if not symbols:
+        return {}
+    conn = connect()
+    try:
+        run_migrations(conn)
+        api = MetricsAPI(conn, window=100)
+        return api.payload(symbols)
+    finally:
+        conn.close()
 
 
 class LiveTab(_BaseFrame):
@@ -35,6 +49,9 @@ class LiveTab(_BaseFrame):
         self._config = dict(config)
         self._client = client or build_client(self._config)
         self._messages: MutableSequence[Mapping[str, str]] = []
+        self._signal_symbols: List[str] = [
+            str(symbol).upper() for symbol in self._config.get("symbols", [])
+        ]
 
         self.system_prompt_text = tk.Text(self, height=4, wrap="word")
         self.chat_log = tk.Text(self, height=14, wrap="word", state="disabled")
@@ -42,6 +59,7 @@ class LiveTab(_BaseFrame):
         self.error_var = tk.StringVar(value="")
         self.latency_var = tk.StringVar(value="Latency: -- ms")
         self.model_var = tk.StringVar(value=str(self._config.get("model", "")))
+        self.signals_table: ttk.Treeview | None = None
 
         self._build_ui()
         self._load_system_prompt()
@@ -78,6 +96,9 @@ class LiveTab(_BaseFrame):
         self.chat_log.configure(state="disabled")
         self.chat_log.pack(in_=chat_frame, fill=tk.BOTH, expand=True, padx=8, pady=8)
 
+        if self._signal_symbols:
+            self._build_signals_panel()
+
         input_frame = ttk.Frame(self, style="DashboardBackground.TFrame")
         input_frame.pack(fill=tk.X, padx=16, pady=(0, 16))
 
@@ -95,6 +116,38 @@ class LiveTab(_BaseFrame):
             foreground=DARK_PALETTE["danger"],
             style="StatusInfo.TLabel",
         ).pack(fill=tk.X, padx=16)
+
+    def _build_signals_panel(self) -> None:
+        container = ttk.LabelFrame(self, text="Signals")
+        container.pack(fill=tk.X, padx=16, pady=(0, 12))
+
+        columns = ("symbol", "confidence", "hit_rate", "expectancy", "entry", "target", "stop")
+        self.signals_table = ttk.Treeview(
+            container,
+            columns=columns,
+            show="headings",
+            height=max(3, len(self._signal_symbols)),
+        )
+        headings = {
+            "symbol": "Symbol",
+            "confidence": "Confidence",
+            "hit_rate": "Hit rate",
+            "expectancy": "Expectancy",
+            "entry": "Entry",
+            "target": "Target",
+            "stop": "Stop",
+        }
+        for column in columns:
+            self.signals_table.heading(column, text=headings[column])
+            self.signals_table.column(column, anchor=tk.CENTER, stretch=True, width=100)
+        self.signals_table.pack(fill=tk.X, padx=8, pady=8)
+
+        actions = ttk.Frame(container, style="DashboardBackground.TFrame")
+        actions.pack(fill=tk.X, padx=8, pady=(0, 8))
+        ttk.Button(actions, text="Refresh", command=self.refresh_signals).pack(
+            side=tk.LEFT
+        )
+        self.refresh_signals()
 
     def _load_system_prompt(self) -> None:
         prompt = str(self._config.get("system_prompt", ""))
@@ -132,6 +185,7 @@ class LiveTab(_BaseFrame):
         self.latency_var.set(f"Latency: {latency_ms:.0f} ms")
         self._messages.append({"role": "assistant", "content": response})
         self._append_to_log("Assistant", response)
+        self.refresh_signals()
 
     def _dispatch(self) -> tuple[str, float]:
         prompt = self.system_prompt_text.get("1.0", tk.END).strip()
@@ -149,3 +203,23 @@ class LiveTab(_BaseFrame):
         self.chat_log.insert(tk.END, f"{speaker}: {safe}\n")
         self.chat_log.configure(state="disabled")
         self.chat_log.see(tk.END)
+
+    def refresh_signals(self) -> Mapping[str, Mapping[str, object]]:
+        if not self._signal_symbols or self.signals_table is None:
+            return {}
+        payload = _fetch_signal_metrics(self._signal_symbols)
+        for item in self.signals_table.get_children():
+            self.signals_table.delete(item)
+        for symbol in self._signal_symbols:
+            metrics = payload.get(symbol, {})
+            row = (
+                symbol,
+                f"{metrics.get('confidence', 0.0):.2f}",
+                f"{metrics.get('hit_rate', 0.0):.2f}",
+                f"{metrics.get('expectancy', 0.0):.4f}",
+                f"{metrics.get('entry', 0.0):.2f}",
+                f"{metrics.get('target', 0.0):.2f}",
+                f"{metrics.get('stop', 0.0):.2f}",
+            )
+            self.signals_table.insert("", tk.END, values=row)
+        return payload


### PR DESCRIPTION
## Summary
- add a SQLite-backed bar feed and streaming inference loop that persists probabilities and realized outcomes
- expose rolling signal metrics for each contract and display them inside the Live tab
- cover the service with an integration test that replays recorded bars through the predictor

## Testing
- pytest tests/test_infer_service.py *(skipped: numpy unavailable in environment)*
- pytest tests/test_nightly_loop.py *(skipped: numpy unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b9355c30832991e3f07ab9022b4c