### PR TITLE
Refresh numeric stack for Python 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,26 +5,26 @@
 The `toptek/requirements-lite.txt` file pins the scientific stack to keep it
 compatible with the bundled scikit-learn release:
 
-- `scikit-learn==1.3.2`
-- `numpy>=1.21.6,<1.28`
-- `scipy>=1.7.3,<1.12`
+- `scikit-learn==1.6.0`
+- `numpy>=2.1.2,<2.3`
+- `scipy>=1.14.1,<1.16`
 
-These ranges follow the support window published by scikit-learn 1.3.x and are
+These ranges follow the support window published by scikit-learn 1.6.x and are
 also consumed transitively by `toptek/requirements-streaming.txt` through its
 `-r requirements-lite.txt` include. Installing within these bounds avoids the
 ABI mismatches that occur with the NumPy/SciPy wheels when using newer major
-releases. In particular, upgrading NumPy beyond `<1.28` causes SciPy to raise
-its "compiled against NumPy 1.x" `ImportError`, mirroring the guidance already
+releases. In particular, upgrading NumPy beyond `<2.3` or SciPy beyond `<1.16`
+risks diverging from the tested wheel set, mirroring the guidance already
 documented in `toptek/README.md`.
 
 ## Verifying the environment
 
-Use Python **3.10 or 3.11**—matching the guidance in `toptek/README.md`'s
+Use Python **3.10 through 3.13**—matching the guidance in `toptek/README.md`'s
 quickstart—to stay within the wheel support window for SciPy and
-scikit-learn 1.3.x. Python 3.12 is currently unsupported because prebuilt
-SciPy/scikit-learn wheels for that interpreter depend on NumPy ≥1.28 and
-SciPy ≥1.12, which exceed this project's pinned ranges. Create and activate a
-compatible virtual environment, then install and check for dependency issues:
+scikit-learn 1.6.x. The refreshed NumPy/SciPy releases ship wheels for CPython
+3.13, unlocking the latest interpreter without requiring source builds. Create
+and activate a compatible virtual environment, then install and check for
+dependency issues:
 
 ```bash
 python -m venv .venv
@@ -36,8 +36,8 @@ pip check
 
 The final `pip check` call should report "No broken requirements found",
 confirming that the pinned dependency set resolves without conflicts. Users on
-Python 3.12 should downgrade to Python 3.10/3.11 or wait for a dependency
-refresh that supports NumPy ≥1.28 and SciPy ≥1.12 before proceeding.
+interpreters older than Python 3.10 or newer than 3.13 should match one of the
+supported versions or wait for a future dependency refresh before proceeding.
 
 ## UI configuration surface
 

--- a/tests/ai_server/test_core_utils.py
+++ b/tests/ai_server/test_core_utils.py
@@ -72,10 +72,10 @@ def test_assert_numeric_stack_pass(monkeypatch):
 
     def fake_version(name: str) -> str:
         recorded[name] = True
-        return "1.3.2" if name == "scikit-learn" else "1.9.0"
+        return "1.6.0" if name == "scikit-learn" else "2.1.2"
 
     monkeypatch.setattr(utils.metadata, "version", fake_version)
-    utils.assert_numeric_stack({"scikit-learn": "==1.3.2", "numpy": ">=1.0"})
+    utils.assert_numeric_stack({"scikit-learn": "==1.6.0", "numpy": ">=2.0"})
     assert recorded["scikit-learn"] is True
 
 

--- a/toptek/core/utils.py
+++ b/toptek/core/utils.py
@@ -125,9 +125,9 @@ def build_paths(root: Path, app_config: Dict[str, Any]) -> AppPaths:
 
 
 STACK_REQUIREMENTS: Dict[str, str | tuple[str, str]] = {
-    "numpy": ">=1.21.6,<1.28",
-    "scipy": ">=1.7.3,<1.12",
-    "scikit-learn": "==1.3.2",
+    "numpy": ">=2.1.2,<2.3",
+    "scipy": ">=1.14.1,<1.16",
+    "scikit-learn": "==1.6.0",
 }
 
 

--- a/toptek/requirements-lite.txt
+++ b/toptek/requirements-lite.txt
@@ -1,8 +1,8 @@
 httpx
 python-dotenv
 pyyaml
-numpy>=1.21.6,<1.28
-scipy>=1.7.3,<1.12
+numpy>=2.1.2,<2.3
+scipy>=1.14.1,<1.16
 ta
-scikit-learn==1.3.2
+scikit-learn==1.6.0
 pandas


### PR DESCRIPTION
## Summary
- bump the pinned numpy, scipy, and scikit-learn versions to the Python 3.13-capable wheel set
- align the runtime stack guard and tests with the refreshed dependency constraints
- document the expanded interpreter support window in the dependency guide

## Testing
- pytest tests/ai_server/test_core_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68e1e5b3c46883298a92b44190a3a3f2