### PR TITLE
Allow Python 3.12-3.13 in runtime guard

### DIFF
--- a/tests/test_stack_guard.py
+++ b/tests/test_stack_guard.py
@@ -70,7 +70,7 @@ def patched_main(monkeypatch):
 def test_main_surfaces_numeric_stack_error(monkeypatch, patched_main):
     """Stack mismatch should raise a helpful RuntimeError before SciPy loads."""
 
-    monkeypatch.setattr(patched_main.sys, "version_info", (3, 11, 0))
+    monkeypatch.setattr(patched_main.sys, "version_info", (3, 13, 0))
     monkeypatch.setitem(utils.STACK_REQUIREMENTS, "numpy", ">=999.0")
     with pytest.raises(RuntimeError) as excinfo:
         patched_main.main()
@@ -80,12 +80,12 @@ def test_main_surfaces_numeric_stack_error(monkeypatch, patched_main):
     assert "pip install -r toptek/requirements-lite.txt" in message
 
 
-def test_main_blocks_python_312(monkeypatch, patched_main):
+def test_main_blocks_python_314(monkeypatch, patched_main):
     """The runtime guard should block unsupported Python interpreters."""
 
-    monkeypatch.setattr(patched_main.sys, "version_info", (3, 12, 0))
+    monkeypatch.setattr(patched_main.sys, "version_info", (3, 14, 0))
     with pytest.raises(RuntimeError) as excinfo:
         patched_main.main()
     message = str(excinfo.value)
-    assert "Python 3.12+" in message
-    assert "Python 3.10 or 3.11" in message
+    assert "Python 3.14+" in message
+    assert "Python 3.10 through 3.13" in message

--- a/toptek/main.py
+++ b/toptek/main.py
@@ -256,10 +256,10 @@ def _filter_dataframe_by_start(df, start: datetime):
 def _guard_interpreter_version() -> None:
     """Abort early when running on an unsupported Python runtime."""
 
-    if sys.version_info >= (3, 12):
+    if sys.version_info >= (3, 14):
         raise RuntimeError(
-            "Python 3.12+ is not supported by the pinned scientific stack; "
-            "please use Python 3.10 or 3.11 until compatible wheels are released."
+            "Python 3.14+ is not supported by the pinned scientific stack; "
+            "please use Python 3.10 through 3.13 until compatible wheels are released."
         )
 
 


### PR DESCRIPTION
## Summary
- relax the interpreter guard to allow Python 3.12 and 3.13 while continuing to block future releases until vetted
- refresh the guard error message to describe the new supported range
- update the stack guard regression tests to reflect the Python 3.14 cutoff

## Testing
- pytest tests/test_stack_guard.py

------
https://chatgpt.com/codex/tasks/task_e_68e1ead220c08329bd86325aa067e8fd