### PR TITLE
Disable trace coverage during CI pytest step

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Black
         run: black --check .
       - name: Pytest
+        env:
+          TOPTEK_SKIP_TRACE_COVERAGE: 1
         run: pytest -q
       - name: Mypy (informational)
         continue-on-error: true


### PR DESCRIPTION
## Summary
- set `TOPTEK_SKIP_TRACE_COVERAGE` for the CI Pytest step so the trace hook stays disabled during automation runs

## Testing
- TOPTEK_SKIP_TRACE_COVERAGE=1 pytest -q *(fails: missing optional pandas dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ffec3b6c8329a5194e6e38cb0ad0