### PR TITLE
Add SignalR live streaming connectors with tests

### DIFF
--- a/tests/core/test_live_streaming.py
+++ b/tests/core/test_live_streaming.py
@@ -1,0 +1,291 @@
+"""Deterministic tests for SignalR live streaming helpers."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+import sys
+import types
+from typing import Any, Callable, Dict, List, Tuple
+
+if "httpx" not in sys.modules:  # pragma: no cover - import shim for optional dependency
+    httpx_stub = types.ModuleType("httpx")
+
+    class _StubResponse:
+        def __init__(self, text: str = "") -> None:
+            self.text = text
+
+        def json(self) -> Dict[str, Any]:  # pragma: no cover - defensive only
+            return {}
+
+    class HTTPStatusError(Exception):
+        def __init__(self, message: str = "", request: Any = None, response: Any = None) -> None:
+            super().__init__(message)
+            self.request = request
+            self.response = response or _StubResponse()
+
+    class Client:  # pragma: no cover - network disabled during tests
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        def post(self, *args: Any, **kwargs: Any) -> Any:
+            raise RuntimeError("HTTP client stub does not support network calls")
+
+        def close(self) -> None:  # noqa: D401 - interface compatibility
+            """No-op close to satisfy gateway expectations."""
+
+    httpx_stub.Client = Client
+    httpx_stub.HTTPStatusError = HTTPStatusError
+    httpx_stub.Response = _StubResponse
+    sys.modules["httpx"] = httpx_stub
+
+import pytest
+
+from toptek.core import live
+
+
+class DummySignalRConnection:
+    """Test double that mimics the minimal SignalR hub API surface."""
+
+    def __init__(self) -> None:
+        self.started = False
+        self.stopped = False
+        self.sent: List[Tuple[str, List[Any]]] = []
+        self._listeners: Dict[str, List[Tuple[str, Callable[[Any], None]]]] = defaultdict(list)
+        self._open_callbacks: List[Callable[[], None]] = []
+        self._close_callbacks: List[Callable[[Any], None]] = []
+        self._counter = 0
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.stopped = True
+
+    def on(self, event: str, handler: Callable[[Any], None]) -> str:
+        token = f"{event}-{self._counter}"
+        self._counter += 1
+        self._listeners[event].append((token, handler))
+        return token
+
+    def remove_listener(self, event: str, identifier: Any) -> None:
+        listeners = self._listeners.get(event, [])
+        if identifier is None:
+            self._listeners[event] = []
+            return
+
+        remaining: List[Tuple[str, Callable[[Any], None]]] = []
+        for token, handler in listeners:
+            if identifier in (token, handler):
+                continue
+            remaining.append((token, handler))
+        self._listeners[event] = remaining
+
+    def off(self, event: str, identifier: Any | None = None) -> None:
+        self.remove_listener(event, identifier)
+
+    def send(self, method: str, args: List[Any]) -> None:
+        self.sent.append((method, args))
+
+    def on_open(self, callback: Callable[[], None]) -> None:
+        self._open_callbacks.append(callback)
+
+    def on_close(self, callback: Callable[[Any], None]) -> None:
+        self._close_callbacks.append(callback)
+
+    def trigger_open(self) -> None:
+        for callback in list(self._open_callbacks):
+            callback()
+
+    def trigger_close(self, error: Any = None) -> None:
+        for callback in list(self._close_callbacks):
+            callback(error)
+
+    def emit(self, event: str, payload: Any) -> None:
+        for _, handler in list(self._listeners.get(event, [])):
+            handler([payload])
+
+
+class DummyHubConnectionBuilder:
+    """Builder double compatible with :func:`connect_market_hub`."""
+
+    instances: List["DummyHubConnectionBuilder"] = []
+
+    def __init__(self) -> None:
+        self.url: str | None = None
+        self.options: Dict[str, Any] | None = None
+        self.connection: DummySignalRConnection = DummySignalRConnection()
+        DummyHubConnectionBuilder.instances.append(self)
+
+    def with_url(self, url: str, options: Dict[str, Any] | None = None) -> "DummyHubConnectionBuilder":
+        self.url = url
+        self.options = options
+        return self
+
+    def build(self) -> DummySignalRConnection:
+        return self.connection
+
+
+@pytest.fixture(autouse=True)
+def reset_builder_instances() -> None:
+    DummyHubConnectionBuilder.instances.clear()
+
+
+def test_connect_market_hub_merges_headers_and_closes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(live, "_require_signalr_builder", lambda: DummyHubConnectionBuilder)
+
+    opened: List[bool] = []
+    closed: List[Any] = []
+
+    handle = live.connect_market_hub(
+        "https://example.com/api",
+        hub_path="stream",
+        headers={"Authorization": "token"},
+        options={"headers": {"User-Agent": "ProjectX"}},
+        on_open=lambda: opened.append(True),
+        on_close=lambda exc: closed.append(exc),
+    )
+
+    assert isinstance(handle, live.HubConnectionHandle)
+    builder = DummyHubConnectionBuilder.instances[-1]
+    assert builder.url == "https://example.com/api/stream"
+    assert builder.options == {
+        "headers": {"User-Agent": "ProjectX", "Authorization": "token"}
+    }
+
+    connection = handle.connection
+    assert connection.started is True
+
+    connection.trigger_open()
+    assert opened == [True]
+
+    connection.trigger_close(None)
+    assert closed == [None]
+
+    handle.close()
+    assert connection.stopped is True
+
+
+def test_subscribe_ticker_dispatch_and_unsubscribe() -> None:
+    connection = DummySignalRConnection()
+    events: List[Tuple[str, Any]] = []
+
+    handle = live.subscribe_ticker(
+        connection,
+        "ES=F",
+        lambda symbol, payload: events.append((symbol, payload)),
+        event="ticker",
+    )
+
+    assert handle.connection is connection
+    assert connection.sent == [("SubscribeTicker", ["ES=F"])]
+
+    connection.emit("ticker", {"bid": 1})
+    assert events == [("ES=F", {"bid": 1})]
+
+    handle.unsubscribe()
+    assert ("UnsubscribeTicker", ["ES=F"]) in connection.sent
+
+    connection.emit("ticker", {"bid": 2})
+    assert events == [("ES=F", {"bid": 1})]
+
+
+def test_subscribe_bars_uses_handle_and_timeframe() -> None:
+    handle = live.HubConnectionHandle(DummySignalRConnection())
+    events: List[Tuple[str, str, Any]] = []
+
+    subscription = live.subscribe_bars(
+        handle,
+        "NQ=F",
+        "1m",
+        lambda symbol, timeframe, payload: events.append((symbol, timeframe, payload)),
+        event="bars",
+    )
+
+    connection = handle.connection
+    assert connection.sent == [("SubscribeBars", ["NQ=F", "1m"])]
+
+    connection.emit("bars", {"close": 4100})
+    assert events == [("NQ=F", "1m", {"close": 4100})]
+
+    subscription.unsubscribe()
+    assert ("UnsubscribeBars", ["NQ=F", "1m"]) in connection.sent
+
+    connection.emit("bars", {"close": 4200})
+    assert events == [("NQ=F", "1m", {"close": 4100})]
+
+
+def test_utils_module_behaviour(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from toptek.core import utils
+
+    logger = utils.build_logger("test-live-streaming", level="DEBUG")
+    assert logger.name == "test-live-streaming"
+
+    yaml_path = tmp_path / "config.yml"
+    yaml_path.write_text("foo: 1\n", encoding="utf-8")
+    assert utils.load_yaml(yaml_path) == {"foo": 1}
+    assert utils.load_yaml(tmp_path / "missing.yml") == {}
+
+    paths = utils.build_paths(
+        tmp_path,
+        {"cache_directory": "cache_dir", "models_directory": "models_dir"},
+    )
+    utils.ensure_directories(paths)
+    assert paths.cache.exists() and paths.models.exists()
+
+    env_key = "TOPTEK_TEST_ENV"
+    monkeypatch.delenv(env_key, raising=False)
+    assert utils.env_or_default(env_key, "fallback") == "fallback"
+    monkeypatch.setenv(env_key, "configured")
+    assert utils.env_or_default(env_key, "fallback") == "configured"
+
+    timestamp = utils.timestamp()
+    assert timestamp.tzinfo == utils.DEFAULT_TIMEZONE
+    json_blob = utils.json_dumps({"ts": timestamp})
+    assert "ts" in json_blob
+
+    assert utils._version_tuple("1.2.3-alpha") == (1, 2, 3)
+    assert utils._version_tuple("1..2") == (1, 2)
+    assert utils._version_tuple("1a.2") == (1, 2)
+    assert utils._version_tuple("a1") == (0,)
+    assert utils._compare_versions((1, 2), (1, 2, 1)) == -1
+    assert utils._spec_matches("2.1.2", ">=2.1,<3") is True
+    assert utils._spec_matches("1.0", ">=0.9,,<2") is True
+    assert utils._spec_matches("1.0", ">= ") is True
+    assert utils._spec_matches("1.0", "==1.1") is False
+
+    resolved_versions = {"numpy": "2.1.2", "scipy": "1.14.1", "scikit-learn": "1.6.0"}
+
+    monkeypatch.setattr(
+        utils.metadata,
+        "version",
+        lambda package: resolved_versions[package],
+    )
+    utils.assert_numeric_stack(
+        {
+            "numpy": ">=2.1.2,<3",
+            "scipy": ">=1.14.1,<2",
+            "scikit-learn": "==1.6.0",
+        }
+    )
+
+    def _version_with_error(package: str) -> str:
+        if package == "numpy":
+            raise utils.PackageNotFoundError
+        if package == "scipy":
+            return "1.14.0"
+        return "1.6.0"
+
+    monkeypatch.setattr(utils.metadata, "version", _version_with_error)
+    with pytest.raises(RuntimeError) as exc:
+        utils.assert_numeric_stack(
+            {
+                "numpy": ">=2.1.2,<3",
+                "scipy": ">=1.14.1,<2",
+                "scikit-learn": "==1.6.0",
+            }
+        )
+
+    message = exc.value.args[0]
+    assert "Missing packages" in message
+    assert "Version mismatches" in message

--- a/toptek/core/live.py
+++ b/toptek/core/live.py
@@ -1,11 +1,17 @@
-"""Live trading utilities with optional SignalR streaming stubs."""
+"""Live trading utilities with optional SignalR streaming helpers."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict
+from typing import Any, Callable, Dict, MutableMapping, Optional, Sequence
 
 from .gateway import ProjectXGateway
+
+
+_STREAMING_IMPORT_MESSAGE = (
+    "SignalR streaming requires the 'signalrcore' package. "
+    "Install it via the streaming extras profile or `pip install signalrcore`."
+)
 
 
 @dataclass
@@ -14,6 +20,38 @@ class ExecutionContext:
 
     gateway: ProjectXGateway
     account_id: str
+
+
+@dataclass
+class HubConnectionHandle:
+    """Wrapper around a SignalR hub connection with a close helper."""
+
+    connection: Any
+
+    def close(self) -> None:
+        """Stop the underlying connection if it exposes a stop method."""
+
+        if hasattr(self.connection, "stop"):
+            self.connection.stop()
+
+
+@dataclass
+class SubscriptionHandle:
+    """Represents an active SignalR subscription that can be torn down."""
+
+    connection: Any
+    event: str
+    handler: Callable[[Any], None]
+    handler_token: Any
+    unsubscribe_method: Optional[str]
+    unsubscribe_payload: Sequence[Any]
+
+    def unsubscribe(self) -> None:
+        """Detach the handler and propagate an unsubscribe message."""
+
+        _remove_listener(self.connection, self.event, self.handler, self.handler_token)
+        if self.unsubscribe_method:
+            self.connection.send(self.unsubscribe_method, list(self.unsubscribe_payload))
 
 
 def poll_open_orders(context: ExecutionContext) -> Dict[str, object]:
@@ -28,28 +66,177 @@ def poll_positions(context: ExecutionContext) -> Dict[str, object]:
     return context.gateway.search_positions({"accountId": context.account_id})
 
 
-def connect_market_hub(*_, **__) -> None:  # pragma: no cover - stub
-    """Placeholder for SignalR market hub connection."""
+def connect_market_hub(
+    base_url: str,
+    *,
+    hub_path: str = "marketHub",
+    headers: Optional[MutableMapping[str, str]] = None,
+    options: Optional[MutableMapping[str, Any]] = None,
+    auto_start: bool = True,
+    on_open: Optional[Callable[[], None]] = None,
+    on_close: Optional[Callable[[Optional[Exception]], None]] = None,
+) -> HubConnectionHandle:
+    """Create and optionally start a SignalR hub connection."""
 
-    raise NotImplementedError(
-        "SignalR streaming is optional; install signalrcore to enable"
+    builder_cls = _require_signalr_builder()
+    normalized_url = _join_url(base_url, hub_path)
+    connection_options = _merge_options(options, headers)
+
+    connection = builder_cls().with_url(normalized_url, options=connection_options).build()
+
+    if on_open and hasattr(connection, "on_open"):
+        connection.on_open(on_open)
+    if on_close and hasattr(connection, "on_close"):
+        connection.on_close(on_close)
+
+    if auto_start and hasattr(connection, "start"):
+        connection.start()
+
+    return HubConnectionHandle(connection)
+
+
+def subscribe_ticker(
+    connection: HubConnectionHandle | Any,
+    symbol: str,
+    callback: Callable[[str, Any], None],
+    *,
+    event: str = "ticker_update",
+    subscribe_method: Optional[str] = "SubscribeTicker",
+    unsubscribe_method: Optional[str] = "UnsubscribeTicker",
+) -> SubscriptionHandle:
+    """Attach a ticker listener and optionally send subscribe/unsubscribe calls."""
+
+    signalr_connection = _unwrap_connection(connection)
+    handler, token = _register_handler(
+        signalr_connection,
+        event,
+        _wrap_payload(callback, symbol),
+    )
+
+    if subscribe_method:
+        signalr_connection.send(subscribe_method, [symbol])
+
+    return SubscriptionHandle(
+        signalr_connection,
+        event,
+        handler,
+        token,
+        unsubscribe_method,
+        [symbol],
     )
 
 
-def subscribe_ticker(*_, **__) -> None:  # pragma: no cover - stub
-    raise NotImplementedError(
-        "SignalR streaming is optional; install signalrcore to enable"
+def subscribe_bars(
+    connection: HubConnectionHandle | Any,
+    symbol: str,
+    timeframe: str,
+    callback: Callable[[str, str, Any], None],
+    *,
+    event: str = "bar_update",
+    subscribe_method: Optional[str] = "SubscribeBars",
+    unsubscribe_method: Optional[str] = "UnsubscribeBars",
+) -> SubscriptionHandle:
+    """Attach a bar listener for the provided symbol and timeframe."""
+
+    signalr_connection = _unwrap_connection(connection)
+    handler, token = _register_handler(
+        signalr_connection,
+        event,
+        _wrap_payload(callback, symbol, timeframe),
+    )
+
+    if subscribe_method:
+        signalr_connection.send(subscribe_method, [symbol, timeframe])
+
+    return SubscriptionHandle(
+        signalr_connection,
+        event,
+        handler,
+        token,
+        unsubscribe_method,
+        [symbol, timeframe],
     )
 
 
-def subscribe_bars(*_, **__) -> None:  # pragma: no cover - stub
-    raise NotImplementedError(
-        "SignalR streaming is optional; install signalrcore to enable"
-    )
+def _require_signalr_builder():
+    try:
+        from signalrcore.hub_connection_builder import HubConnectionBuilder
+    except ImportError as exc:  # pragma: no cover - exercised via tests
+        raise RuntimeError(_STREAMING_IMPORT_MESSAGE) from exc
+
+    return HubConnectionBuilder
+
+
+def _unwrap_connection(connection: HubConnectionHandle | Any) -> Any:
+    return connection.connection if isinstance(connection, HubConnectionHandle) else connection
+
+
+def _register_handler(connection: Any, event: str, handler: Callable[[Any], None]) -> tuple[Callable[[Any], None], Any]:
+    token = connection.on(event, handler)
+    return handler, token
+
+
+def _wrap_payload(
+    callback: Callable[..., None],
+    *prefix_args: str,
+) -> Callable[[Any], None]:
+    def _inner(message: Any) -> None:
+        payload = _extract_payload(message)
+        callback(*prefix_args, payload)
+
+    return _inner
+
+
+def _extract_payload(message: Any) -> Any:
+    if isinstance(message, (list, tuple)):
+        return message[0] if message else None
+    return message
+
+
+def _remove_listener(connection: Any, event: str, handler: Callable[[Any], None], token: Any) -> None:
+    if hasattr(connection, "remove_listener"):
+        try:
+            connection.remove_listener(event, token if token is not None else handler)
+            return
+        except TypeError:
+            connection.remove_listener(event, handler)
+
+    if hasattr(connection, "off"):
+        try:
+            if token is not None:
+                connection.off(event, token)
+                return
+        except TypeError:
+            pass
+        try:
+            connection.off(event, handler)
+            return
+        except TypeError:
+            connection.off(event)
+
+
+def _merge_options(
+    options: Optional[MutableMapping[str, Any]],
+    headers: Optional[MutableMapping[str, str]],
+) -> MutableMapping[str, Any]:
+    merged: Dict[str, Any] = dict(options or {})
+    if headers:
+        merged_headers = dict(merged.get("headers", {}))
+        merged_headers.update(headers)
+        merged["headers"] = merged_headers
+    return merged
+
+
+def _join_url(base_url: str, hub_path: str) -> str:
+    if not hub_path:
+        return base_url
+    return f"{base_url.rstrip('/')}/{hub_path.lstrip('/')}"
 
 
 __all__ = [
     "ExecutionContext",
+    "HubConnectionHandle",
+    "SubscriptionHandle",
     "poll_open_orders",
     "poll_positions",
     "connect_market_hub",


### PR DESCRIPTION
## Summary
- replace the live streaming stubs with SignalR connection helpers that expose handles for closing and unsubscribing
- add deterministic streaming tests that monkeypatch the SignalR builder, validate subscription dispatch, and exercise numeric stack guards
- provide a lightweight httpx shim so the streaming tests run without the optional dependency

## Testing
- pytest tests/core/test_live_streaming.py

------
https://chatgpt.com/codex/tasks/task_e_68e2913a0ac0832993415caced17619e