### PR TITLE
Lazily initialize rate limiter lock

### DIFF
--- a/tests/api/test_gateway_routes.py
+++ b/tests/api/test_gateway_routes.py
@@ -7,7 +7,7 @@ import pytest
 
 from toptek.ai_server._fastapi_stub import FastAPI, HTTPException
 from toptek.api.models import GatewaySettings, RequiredGatewayEnv, load_gateway_settings
-from toptek.api.routes_gateway import register_gateway_routes
+from toptek.api.routes_gateway import RateLimiter, register_gateway_routes
 
 
 class DummyGateway:
@@ -57,6 +57,17 @@ class LiveStub:
                 stub.closed.append((base_url, hub_path))
 
         return _Handle()
+
+
+def test_rate_limiter_lazy_lock_instantiation() -> None:
+    limiter = RateLimiter()
+
+    async def _use_limiter() -> None:
+        async with limiter:
+            pass
+
+    asyncio.run(_use_limiter())
+    assert limiter._lock is not None
 
 
 def _settings() -> GatewaySettings:


### PR DESCRIPTION
## Summary
- lazily create the RateLimiter lock within __aenter__ so construction can happen off loop
- allow _call_gateway to handle an optional limiter instance
- add a regression test ensuring the RateLimiter can be constructed before the loop starts

## Testing
- TOPTEK_SKIP_TRACE_COVERAGE=1 pytest tests/api/test_gateway_routes.py::test_rate_limiter_lazy_lock_instantiation

------
https://chatgpt.com/codex/tasks/task_e_68e2c2f0a8708329ab141742b76da63f