### PR TITLE
Add gateway account snapshot endpoint

### DIFF
--- a/tests/api/test_gateway_routes.py
+++ b/tests/api/test_gateway_routes.py
@@ -7,12 +7,24 @@ import pytest
 
 from toptek.ai_server._fastapi_stub import FastAPI, HTTPException
 from toptek.api.models import GatewaySettings, RequiredGatewayEnv, load_gateway_settings
-from toptek.api.routes_gateway import register_gateway_routes
+from toptek.api.routes_gateway import RateLimiter, register_gateway_routes
 
 
 class DummyGateway:
     def __init__(self) -> None:
         self.calls: list[tuple[str, dict[str, object]]] = []
+        self.account_response: dict[str, object] = {
+            "accounts": [
+                {
+                    "accountId": "U12345",
+                    "accountName": "Main",
+                    "available": 125000.0,
+                    "allocated": 50000.0,
+                    "profit": 2500.5,
+                    "equity": 175000.5,
+                }
+            ]
+        }
 
     def place_order(self, payload: dict[str, object]) -> dict[str, object]:
         self.calls.append(("place_order", dict(payload)))
@@ -20,6 +32,10 @@ class DummyGateway:
 
     def login(self) -> None:
         self.calls.append(("login", {}))
+
+    def search_accounts(self, payload: dict[str, object]) -> dict[str, object]:
+        self.calls.append(("search_accounts", dict(payload)))
+        return dict(self.account_response)
 
     def __getattr__(self, item: str):
         def _call(payload: dict[str, object]) -> dict[str, object]:
@@ -57,6 +73,17 @@ class LiveStub:
                 stub.closed.append((base_url, hub_path))
 
         return _Handle()
+
+
+def test_rate_limiter_lazy_lock_instantiation() -> None:
+    limiter = RateLimiter()
+
+    async def _use_limiter() -> None:
+        async with limiter:
+            pass
+
+    asyncio.run(_use_limiter())
+    assert limiter._lock is not None
 
 
 def _settings() -> GatewaySettings:
@@ -177,3 +204,56 @@ def test_gateway_health_captures_failures() -> None:
     assert "login failed" in report["details"]["rest"]
     assert "hub down" in report["details"]["market_hub"]
     assert "hub down" in report["details"]["user_hub"]
+
+
+def test_gateway_account_snapshot() -> None:
+    app = FastAPI(title="test")
+    gateway = DummyGateway()
+    limiter = DummyLimiter()
+    settings = _settings()
+
+    register_gateway_routes(
+        app,
+        gateway_settings=settings,
+        gateway=gateway,
+        rate_limiter=limiter,
+    )
+
+    handler = app.get_route("GET", "/gateway/account")
+    request = SimpleNamespace(headers={"X-API-Key": settings.api_key})
+    snapshot = asyncio.run(handler(request))
+
+    assert snapshot == {
+        "accounts": [
+            {
+                "id": "U12345",
+                "name": "Main",
+                "available": 125000.0,
+                "allocated": 50000.0,
+                "profit": 2500.5,
+                "equity": 175000.5,
+            }
+        ]
+    }
+    assert ("search_accounts", {}) in gateway.calls
+    assert limiter.entered >= 1
+
+
+def test_gateway_account_requires_api_key() -> None:
+    app = FastAPI(title="test")
+    gateway = DummyGateway()
+    settings = _settings()
+
+    register_gateway_routes(
+        app,
+        gateway_settings=settings,
+        gateway=gateway,
+    )
+
+    handler = app.get_route("GET", "/gateway/account")
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(handler(SimpleNamespace(headers={})))
+
+    assert excinfo.value.status_code == 401
+    assert ("search_accounts", {}) not in gateway.calls

--- a/toptek/api/routes_gateway.py
+++ b/toptek/api/routes_gateway.py
@@ -33,10 +33,12 @@ class RateLimiter:
     min_interval_seconds: float = 0.25
 
     def __post_init__(self) -> None:
-        self._lock = asyncio.Lock()
+        self._lock: asyncio.Lock | None = None
         self._last_call = 0.0
 
     async def __aenter__(self) -> None:
+        if self._lock is None:
+            self._lock = asyncio.Lock()
         await self._lock.acquire()
         now = time.monotonic()
         delay = self.min_interval_seconds - (now - self._last_call)
@@ -45,6 +47,8 @@ class RateLimiter:
         self._last_call = time.monotonic()
 
     async def __aexit__(self, exc_type, exc, tb) -> bool:
+        if self._lock is None:
+            raise RuntimeError("RateLimiter lock missing during release")
         self._lock.release()
         return False
 
@@ -63,6 +67,51 @@ def _normalize_payload(payload: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
     raise HTTPException(status_code=400, detail="Payload must be an object")
 
 
+def _coerce_float(value: Any) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return 0.0
+    return 0.0
+
+
+def _numeric_field(raw: Mapping[str, Any], *candidates: str) -> float:
+    for key in candidates:
+        if key in raw and raw[key] is not None:
+            return _coerce_float(raw[key])
+    return 0.0
+
+
+def _summarize_accounts(response: Mapping[str, Any]) -> Dict[str, Any]:
+    accounts = response.get("accounts")
+    if not isinstance(accounts, list) or not accounts:
+        raise HTTPException(status_code=502, detail="Gateway returned no accounts")
+
+    summaries = []
+    for raw in accounts:
+        if not isinstance(raw, Mapping):
+            continue
+        summary = {
+            "id": raw.get("accountId") or raw.get("id"),
+            "name": raw.get("accountName") or raw.get("name"),
+            "available": _numeric_field(raw, "available", "cashAvailable"),
+            "allocated": _numeric_field(raw, "allocated", "marginUsed"),
+            "profit": _numeric_field(raw, "profit", "profitLoss"),
+            "equity": _numeric_field(raw, "equity", "netLiquidation"),
+        }
+        summaries.append(summary)
+
+    if not summaries:
+        raise HTTPException(
+            status_code=502, detail="Gateway returned invalid account payload"
+        )
+
+    return {"accounts": summaries}
+
+
 def _headers_from_request(request: Request | None) -> Mapping[str, str]:
     if request is None:
         return {}
@@ -77,8 +126,10 @@ def _headers_from_request(request: Request | None) -> Mapping[str, str]:
 async def _call_gateway(
     func: Callable[[Dict[str, Any]], Dict[str, Any]],
     payload: Dict[str, Any],
-    limiter: RateLimiter,
+    limiter: RateLimiter | None,
 ) -> Dict[str, Any]:
+    if limiter is None:
+        return await asyncio.to_thread(func, payload)
     async with limiter:
         return await asyncio.to_thread(func, payload)
 
@@ -171,6 +222,17 @@ def register_gateway_routes(
         await _probe_hub(settings.market_hub_base, settings.market_hub_path, "market_hub")
         await _probe_hub(settings.user_hub_base, settings.user_hub_path, "user_hub")
         return report
+
+    @app.get("/gateway/account")
+    async def gateway_account(request: Request | None = None) -> Dict[str, Any]:
+        headers = _headers_from_request(request)
+        _require_api_key(headers, settings.api_key)
+        raw = await _call_gateway(client.search_accounts, {}, limiter)
+        if not isinstance(raw, Mapping):
+            raise HTTPException(
+                status_code=502, detail="Gateway returned unexpected account payload"
+            )
+        return _summarize_accounts(raw)
 
     async def _reject_websocket(websocket: WebSocket, *, reason: str) -> None:
         await websocket.close(code=1008, reason=reason)


### PR DESCRIPTION
## Summary
- add a GET /gateway/account route that reuses the shared rate limiter and normalizes account summaries
- extend the gateway tests with account snapshot and API key enforcement coverage
- keep the lazy rate limiter behavior validated through the existing regression test

## Testing
- TOPTEK_SKIP_TRACE_COVERAGE=1 pytest tests/api/test_gateway_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68e2c2f0a8708329ab141742b76da63f