### PR TITLE
Add ttkbootstrap adapter for GUI theming

### DIFF
--- a/toptek/_ui_theme.py
+++ b/toptek/_ui_theme.py
@@ -1,0 +1,56 @@
+"""Helpers for working with optional ttkbootstrap theming."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from functools import lru_cache
+from typing import Mapping
+
+from toptek.gui import DARK_PALETTE
+
+_THEME_TOKEN_MAP: Mapping[str, str] = {
+    "dark": "superhero",
+    "light": "flatly",
+}
+
+
+def _resolve_theme_name(theme: str | None) -> str | None:
+    if not theme:
+        return None
+    canonical = theme.strip().lower()
+    return _THEME_TOKEN_MAP.get(canonical, theme)
+
+
+@lru_cache(maxsize=1)
+def _import_ttkbootstrap():  # pragma: no cover - optional dependency
+    try:
+        import ttkbootstrap  # type: ignore
+    except Exception:
+        return None
+    return ttkbootstrap
+
+
+def get_window(theme: str | None):
+    """Return a themed root window using ttkbootstrap when available."""
+
+    resolved = _resolve_theme_name(theme)
+    ttkbootstrap = _import_ttkbootstrap()
+    if ttkbootstrap is not None:
+        themename = resolved or "superhero"
+        return ttkbootstrap.Window(themename=themename)
+
+    root = tk.Tk()
+    root.configure(background=DARK_PALETTE["canvas"])
+    return root
+
+
+def apply_base_spacing(root: tk.Misc) -> None:
+    """Apply baseline spacing tweaks for classic Tk deployments."""
+
+    if _import_ttkbootstrap() is not None:
+        return
+
+    root.option_add("*TCombobox*Listbox.background", DARK_PALETTE["surface"])
+    root.option_add("*TCombobox*Listbox.foreground", DARK_PALETTE["text"])
+    root.option_add("*TCombobox*Listbox.selectBackground", DARK_PALETTE["accent"])
+    root.option_add("*TCombobox*Listbox.selectForeground", DARK_PALETTE["canvas"])


### PR DESCRIPTION
## Summary
- add a reusable `_ui_theme` helper to create themed windows and spacing with optional ttkbootstrap support
- update `launch_app` to consume the new window helper, map accent choices when ttkbootstrap is present, and keep the DARK_PALETTE fallback styling
- defer the optional ttkbootstrap import to window creation so classic Tk deployments stay lightweight

## Testing
- TOPTEK_SKIP_TRACE_COVERAGE=1 pytest tests/gui/test_tab_builder_guard.py

------
https://chatgpt.com/codex/tasks/task_e_68e2d578422c83299f017f9c43d91704