### PR TITLE
Patch ttkbootstrap keyword parsing for dashboard style

### DIFF
--- a/toptek/_ui_theme.py
+++ b/toptek/_ui_theme.py
@@ -1,0 +1,75 @@
+"""Helpers for working with optional ttkbootstrap theming."""
+
+from __future__ import annotations
+
+import re
+import tkinter as tk
+from functools import lru_cache
+from typing import Mapping
+
+from toptek.gui import DARK_PALETTE
+
+_THEME_TOKEN_MAP: Mapping[str, str] = {
+    "dark": "superhero",
+    "light": "flatly",
+}
+
+
+def _resolve_theme_name(theme: str | None) -> str | None:
+    if not theme:
+        return None
+    canonical = theme.strip().lower()
+    return _THEME_TOKEN_MAP.get(canonical, theme)
+
+
+@lru_cache(maxsize=1)
+def _import_ttkbootstrap():  # pragma: no cover - optional dependency
+    try:
+        import ttkbootstrap  # type: ignore
+    except Exception:
+        return None
+    return ttkbootstrap
+
+
+def _patch_bootstrap_keywords() -> None:
+    """Prevent ttkbootstrap from mis-detecting our custom style names."""
+
+    try:  # pragma: no cover - optional dependency
+        from ttkbootstrap.style import Keywords  # type: ignore
+    except Exception:  # pragma: no cover - defensive
+        return
+
+    if getattr(Keywords, "_toptek_background_patch", False):
+        return
+
+    Keywords.TYPE_PATTERN = re.compile(
+        r"outline|link|inverse|(?<!back)round|square|striped|focus|input|date|metersubtxt|meter|table"
+    )
+    Keywords._toptek_background_patch = True
+
+
+def get_window(theme: str | None):
+    """Return a themed root window using ttkbootstrap when available."""
+
+    resolved = _resolve_theme_name(theme)
+    ttkbootstrap = _import_ttkbootstrap()
+    if ttkbootstrap is not None:
+        _patch_bootstrap_keywords()
+        themename = resolved or "superhero"
+        return ttkbootstrap.Window(themename=themename)
+
+    root = tk.Tk()
+    root.configure(background=DARK_PALETTE["canvas"])
+    return root
+
+
+def apply_base_spacing(root: tk.Misc) -> None:
+    """Apply baseline spacing tweaks for classic Tk deployments."""
+
+    if _import_ttkbootstrap() is not None:
+        return
+
+    root.option_add("*TCombobox*Listbox.background", DARK_PALETTE["surface"])
+    root.option_add("*TCombobox*Listbox.foreground", DARK_PALETTE["text"])
+    root.option_add("*TCombobox*Listbox.selectBackground", DARK_PALETTE["accent"])
+    root.option_add("*TCombobox*Listbox.selectForeground", DARK_PALETTE["canvas"])

--- a/toptek/_ui_theme.py
+++ b/toptek/_ui_theme.py
@@ -43,7 +43,7 @@ def _patch_bootstrap_keywords() -> None:
         return
 
     Keywords.TYPE_PATTERN = re.compile(
-        r"outline|link|inverse|(?<!back)round|square|striped|focus|input|date|metersubtxt|meter|table"
+        "outline|link|inverse|\\bround\\b|square|striped|focus|input|date|metersubtxt|meter|table"
     )
     Keywords._toptek_background_patch = True
 


### PR DESCRIPTION
## Summary
- patch ttkbootstrap's keyword pattern so custom DashboardBackground styles no longer trigger the round frame builder
- apply the regex fix during themed window creation while leaving the legacy Tk fallback untouched

## Testing
- TOPTEK_SKIP_TRACE_COVERAGE=1 pytest tests/gui/test_tab_builder_guard.py

------
https://chatgpt.com/codex/tasks/task_e_68e2d578422c83299f017f9c43d91704