### PR TITLE
Refactor UI root initialization

### DIFF
--- a/toptek/gui/app.py
+++ b/toptek/gui/app.py
@@ -9,8 +9,7 @@ from typing import Callable, Dict, List
 from core import utils
 
 from . import DARK_PALETTE
-from toptek._ui_theme import apply_base_spacing, get_window
-from toptek._ui_theme import BOOTSTRAP_AVAILABLE, apply_base_spacing, get_window
+from toptek._ui_theme import BOOTSTRAP_AVAILABLE
 
 
 def _resolve_bootstrap_accent(accent: object) -> str:
@@ -239,7 +238,9 @@ class ToptekApp(ttk.Notebook):
         self._on_tab_change(index, name, guidance)
 
 
-def launch_app(*, configs: Dict[str, Dict[str, object]], paths: utils.AppPaths) -> None:
+def launch_app(
+    *, root: tk.Misc, configs: Dict[str, Dict[str, object]], paths: utils.AppPaths
+) -> None:
     """Initialise and start the Tkinter main loop."""
 
     ui_config = configs.get("ui", {})
@@ -249,11 +250,8 @@ def launch_app(*, configs: Dict[str, Dict[str, object]], paths: utils.AppPaths) 
         if isinstance(maybe_appearance, dict):
             appearance = maybe_appearance
 
-    theme_value = appearance.get("theme") if isinstance(appearance.get("theme"), str) else None
     accent_value = appearance.get("accent") if isinstance(appearance.get("accent"), str) else None
 
-    root = get_window(theme_value)
-    apply_base_spacing(root)
     root.title("Toptek Mission Control")
     root.geometry("1024x680")
 

--- a/toptek/main.py
+++ b/toptek/main.py
@@ -360,9 +360,9 @@ def main() -> None:
         run_cli(args, configs, paths)
         return
 
-    from gui.app import launch_app  # imported lazily to avoid Tkinter cost
+    from toptek.ui.main import launch_ui  # imported lazily to avoid Tkinter cost
 
-    launch_app(configs=configs, paths=paths)
+    launch_ui(configs=configs, paths=paths)
 
 
 if __name__ == "__main__":

--- a/toptek/ui/_ui_theme.py
+++ b/toptek/ui/_ui_theme.py
@@ -1,0 +1,28 @@
+"""Bridge module providing Tk window helpers for the UI entry point."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from typing import Optional
+
+from toptek._ui_theme import apply_base_spacing as _apply_base_spacing
+from toptek._ui_theme import get_window as _get_window
+
+_CURRENT_ROOT: Optional[tk.Misc] = None
+
+
+def get_window(theme: str | None):
+    """Return a themed root window and memoise it for style defaults."""
+
+    global _CURRENT_ROOT
+    root = _get_window(theme)
+    _CURRENT_ROOT = root
+    return root
+
+
+def maybe_apply_style_defaults() -> None:
+    """Apply baseline style defaults if ttkbootstrap is unavailable."""
+
+    if _CURRENT_ROOT is None:
+        return
+    _apply_base_spacing(_CURRENT_ROOT)

--- a/toptek/ui/main.py
+++ b/toptek/ui/main.py
@@ -1,0 +1,29 @@
+"""Graphical entry point responsible for constructing the Tk root."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from toptek.core import utils
+from toptek.gui.app import launch_app
+from toptek.ui._ui_theme import get_window, maybe_apply_style_defaults
+
+
+def _resolve_theme(configs: Dict[str, Dict[str, object]]) -> str | None:
+    ui_config = configs.get("ui", {})
+    if not isinstance(ui_config, dict):
+        return None
+    appearance = ui_config.get("appearance", {})
+    if not isinstance(appearance, dict):
+        return None
+    theme_value = appearance.get("theme")
+    return theme_value if isinstance(theme_value, str) else None
+
+
+def launch_ui(*, configs: Dict[str, Dict[str, object]], paths: utils.AppPaths) -> None:
+    """Create the Tk root window and delegate to the main application."""
+
+    theme_value = _resolve_theme(configs)
+    root = get_window(theme=theme_value)
+    maybe_apply_style_defaults()
+    launch_app(root=root, configs=configs, paths=paths)


### PR DESCRIPTION
## Summary
- add a UI entry module that builds the Tk root and delegates to the existing app
- wrap the shared theme helpers to memoise the root for style defaults
- update the application bootstrap to accept an injected root and wire the main entry point to the new launcher

## Testing
- python -m compileall toptek/ui/_ui_theme.py toptek/ui/main.py toptek/gui/app.py toptek/main.py

------
https://chatgpt.com/codex/tasks/task_e_68e2e3a396a08329ab836a2fb8a3d3d0